### PR TITLE
WAAPI logo play and hidden easter eggs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,7 +106,14 @@ There is no unit test suite; validation is building + link checking.
 - **Imports**: use the `@/` alias (`@/components/...`, `@/layouts/...`).
 - **Islands**: interactivity goes in Vue SFCs under `src/components/vue/`,
   hydrated with `client:visible` (below the fold) or `client:load`; props must
-  be JSON-serializable. Respect `prefers-reduced-motion`.
+  be JSON-serializable. Respect `prefers-reduced-motion` — headless Chrome
+  forces it, so test checks must accept both paths.
+- **WAAPI easter eggs** (keep them working, don't spoil them in visible copy):
+  header logo on the home page — hover wobble, click pulse, every 3rd click is
+  the "ribosome shuffle" (lenses split and snap back); Konami code summons a
+  brand-colored hex rain; typing `decrypt` replays the hero scramble; the hero
+  watermark rotates on scroll via `ScrollTimeline`. All are covered by
+  `scripts/e2e-cdp.mjs` (25 checks).
 - **Search**: Pagefind index is generated post-build (`pagefind --site dist`);
   the `SiteSearch` island loads `/pagefind/pagefind.js` at runtime (absent in
   plain `astro dev`).

--- a/scripts/e2e-cdp.mjs
+++ b/scripts/e2e-cdp.mjs
@@ -145,6 +145,33 @@ check('home: overlay header nav text is white over hero', navColor.startsWith('r
 const logoColor = await evaluate(`getComputedStyle(document.querySelector('.site-logo')).color`);
 check('home: overlay header logo is white over hero', logoColor === 'rgb(255, 255, 255)', logoColor);
 
+// WAAPI easter eggs
+await evaluate(`document.querySelector('.site-logo')?.click()`);
+await sleep(250);
+check(
+  'home: logo click triggers WAAPI animation (no navigation)',
+  (await evaluate(`document.getAnimations().length > 0 && location.pathname === '/'`)) === true,
+);
+await evaluate(`document.querySelector('.site-logo')?.click(); document.querySelector('.site-logo')?.click()`);
+await sleep(250);
+check('home: triple-click triggers the ribosome shuffle', (await evaluate(`document.getAnimations().length > 0`)) === true);
+
+await evaluate(`['ArrowUp','ArrowUp','ArrowDown','ArrowDown','ArrowLeft','ArrowRight','ArrowLeft','ArrowRight','b','a'].forEach(k => window.dispatchEvent(new KeyboardEvent('keydown', { key: k })))`);
+await sleep(600);
+check(
+  'home: Konami code triggers the egg (canvas rain, or toast when reduced-motion)',
+  (await evaluate(`!!document.querySelector('canvas[aria-hidden="true"]') || (document.querySelector('[role="status"]')?.textContent ?? '').includes('Entropy acquired')`)) === true,
+);
+await sleep(3400);
+
+await evaluate(`'decrypt'.split('').forEach(k => window.dispatchEvent(new KeyboardEvent('keydown', { key: k })))`);
+await sleep(500);
+check(
+  'home: typing "decrypt" replays the hero scramble',
+  (await evaluate(`(document.querySelector('[role="status"]')?.textContent ?? '').includes('Replaying decryption')`)) === true,
+);
+await sleep(1500);
+
 // fingerprint widget (scroll into view to trigger client:visible hydration)
 await evaluate(`document.querySelector('#fp-input')?.scrollIntoView({ block: 'center' })`);
 await sleep(1200);

--- a/src/components/vue/EasterEggs.vue
+++ b/src/components/vue/EasterEggs.vue
@@ -1,0 +1,141 @@
+<script setup lang="ts">
+import { nextTick, onMounted, onUnmounted, ref, watch } from 'vue';
+
+const toastMsg = ref('');
+const toastEl = ref<HTMLElement | null>(null);
+let toastTimer: ReturnType<typeof setTimeout> | undefined;
+
+const reducedMotion = () => matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+const toast = (msg: string) => {
+  toastMsg.value = msg;
+  clearTimeout(toastTimer);
+  toastTimer = setTimeout(() => (toastMsg.value = ''), 2400);
+};
+
+watch(toastMsg, async (msg) => {
+  if (!msg) return;
+  await nextTick();
+  toastEl.value?.animate(
+    [
+      { opacity: 0, transform: 'translate(-50%, 10px)' },
+      { opacity: 1, transform: 'translate(-50%, 0)' },
+    ],
+    { duration: 220, easing: 'cubic-bezier(.22, 1, .36, 1)' },
+  );
+});
+
+/* ---- Konami code → brand-colored hex rain (WAAPI + canvas) ---- */
+const KONAMI = [
+  'arrowup',
+  'arrowup',
+  'arrowdown',
+  'arrowdown',
+  'arrowleft',
+  'arrowright',
+  'arrowleft',
+  'arrowright',
+  'b',
+  'a',
+];
+let seq: string[] = [];
+let word = '';
+
+const hexRain = () => {
+  if (reducedMotion()) {
+    toast('Entropy acquired ✓');
+    return;
+  }
+  const canvas = document.createElement('canvas');
+  canvas.className = 'pointer-events-none fixed inset-0 z-[90]';
+  canvas.setAttribute('aria-hidden', 'true');
+  document.body.appendChild(canvas);
+  const ctx = canvas.getContext('2d')!;
+  canvas.width = innerWidth;
+  canvas.height = innerHeight;
+
+  const glyphs = '0123456789ABCDEF';
+  const colors = ['#1a7bec', '#00dfb7', '#ffdc4a'];
+  const fontSize = 16;
+  const cols = Math.ceil(canvas.width / fontSize);
+  const drops = Array.from({ length: cols }, () => ({
+    y: Math.random() * -canvas.height,
+    speed: 1.5 + Math.random() * 3.5,
+    color: colors[Math.floor(Math.random() * colors.length)],
+  }));
+
+  let raf = 0;
+  const DURATION = 3400;
+  const start = performance.now();
+  canvas.animate([{ opacity: 0 }, { opacity: 1 }], { duration: 250, fill: 'forwards' });
+
+  const tick = (now: number) => {
+    ctx.fillStyle = 'rgba(8, 10, 22, 0.14)';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    ctx.font = `${fontSize}px "IBM Plex Mono", monospace`;
+    for (let i = 0; i < cols; i++) {
+      const d = drops[i];
+      ctx.fillStyle = d.color;
+      ctx.fillText(glyphs[Math.floor(Math.random() * glyphs.length)], i * fontSize, d.y);
+      d.y += d.speed * fontSize * 0.55;
+      if (d.y > canvas.height) {
+        d.y = Math.random() * -220;
+        d.speed = 1.5 + Math.random() * 3.5;
+        d.color = colors[Math.floor(Math.random() * colors.length)];
+      }
+    }
+    if (now - start < DURATION) {
+      raf = requestAnimationFrame(tick);
+    } else {
+      canvas
+        .animate([{ opacity: 1 }, { opacity: 0 }], { duration: 450, fill: 'forwards' })
+        .finished.then(() => {
+          cancelAnimationFrame(raf);
+          canvas.remove();
+          toast('Entropy acquired ✓');
+        });
+    }
+  };
+  raf = requestAnimationFrame(tick);
+};
+
+const onKey = (e: KeyboardEvent) => {
+  const t = e.target as HTMLElement | null;
+  if (t && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable)) return;
+  const k = e.key.toLowerCase();
+
+  seq.push(k);
+  if (seq.length > KONAMI.length) seq.shift();
+  if (seq.join(',') === KONAMI.join(',')) {
+    seq = [];
+    hexRain();
+    return;
+  }
+
+  if (/^[a-z]$/.test(k)) {
+    word = (word + k).slice(-12);
+    if (word.endsWith('decrypt')) {
+      word = '';
+      window.dispatchEvent(new CustomEvent('rnp:replay-hero'));
+      toast('Replaying decryption…');
+    }
+  }
+};
+
+onMounted(() => window.addEventListener('keydown', onKey));
+onUnmounted(() => {
+  window.removeEventListener('keydown', onKey);
+  clearTimeout(toastTimer);
+});
+</script>
+
+<template>
+  <div
+    v-if="toastMsg"
+    ref="toastEl"
+    class="card fixed bottom-6 left-1/2 z-[95] -translate-x-1/2 px-4 py-2 font-mono text-sm text-foreground shadow-lift"
+    role="status"
+  >
+    {{ toastMsg }}
+  </div>
+</template>

--- a/src/components/vue/HeroDecrypt.vue
+++ b/src/components/vue/HeroDecrypt.vue
@@ -1,18 +1,18 @@
 <script setup lang="ts">
-import { onMounted, ref } from 'vue';
+import { onMounted, onUnmounted, ref } from 'vue';
 
 const props = defineProps<{ text: string }>();
 
 const GLYPHS = '0123456789ABCDEF$#@%&*+=~';
 const display = ref(props.text);
+let raf = 0;
 
-onMounted(() => {
-  if (matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+const run = () => {
+  cancelAnimationFrame(raf);
   const text = props.text;
   const total = text.length;
   const duration = 1400;
   const start = performance.now();
-  let raf = 0;
 
   const tick = (now: number) => {
     const t = Math.min(1, (now - start) / duration);
@@ -28,6 +28,20 @@ onMounted(() => {
     else display.value = text;
   };
   raf = requestAnimationFrame(tick);
+};
+
+const maybeRun = () => {
+  if (!matchMedia('(prefers-reduced-motion: reduce)').matches) run();
+};
+
+onMounted(() => {
+  maybeRun();
+  window.addEventListener('rnp:replay-hero', maybeRun);
+});
+
+onUnmounted(() => {
+  cancelAnimationFrame(raf);
+  window.removeEventListener('rnp:replay-hero', maybeRun);
 });
 </script>
 

--- a/src/components/vue/SiteHeader.vue
+++ b/src/components/vue/SiteHeader.vue
@@ -18,7 +18,69 @@ const hidden = ref(false);
 const scrolled = ref(false);
 const mobileOpen = ref(false);
 const mounted = ref(false);
+const logoSvg = ref<SVGSVGElement | null>(null);
 let lastY = 0;
+let clickCount = 0;
+let clickTimer: ReturnType<typeof setTimeout> | undefined;
+
+const reducedMotion = () => matchMedia('(prefers-reduced-motion: reduce)').matches;
+const SPRING = 'cubic-bezier(.22, 1.4, .36, 1)';
+
+/** WAAPI logo play: wobble on hover, pulse per click, lens-shuffle every 3rd. */
+const onLogoEnter = () => {
+  if (!logoSvg.value || reducedMotion()) return;
+  logoSvg.value.animate(
+    [
+      { transform: 'rotate(0deg)' },
+      { transform: 'rotate(-7deg)' },
+      { transform: 'rotate(4deg)' },
+      { transform: 'rotate(0deg)' },
+    ],
+    { duration: 500, easing: 'ease-out' },
+  );
+};
+
+const onLogoClick = (e: MouseEvent) => {
+  if (props.currentPath !== '/') return; // normal navigation elsewhere
+  e.preventDefault();
+  if (reducedMotion() || !logoSvg.value) return;
+  clickCount++;
+  clearTimeout(clickTimer);
+  clickTimer = setTimeout(() => (clickCount = 0), 900);
+  if (clickCount % 3 === 0) shuffleLenses();
+  else
+    logoSvg.value.animate(
+      [
+        { transform: 'scale(1)' },
+        { transform: 'scale(1.18) rotate(-4deg)' },
+        { transform: 'scale(1)' },
+      ],
+      { duration: 450, easing: SPRING },
+    );
+};
+
+/** The ribosome shuffle: the two outer lenses part and snap back, center pulses. */
+const shuffleLenses = () => {
+  const lenses = logoSvg.value?.querySelectorAll('.lens') ?? [];
+  const moves = [20, -20];
+  lenses.forEach((lens, i) => {
+    if (i < 2) {
+      (lens as SVGGraphicsElement).animate(
+        [
+          { transform: 'translateX(0)' },
+          { transform: `translateX(${moves[i]}px)` },
+          { transform: 'translateX(0)' },
+        ],
+        { duration: 700, easing: SPRING },
+      );
+    } else {
+      (lens as SVGGraphicsElement).animate(
+        [{ transform: 'scale(1)' }, { transform: 'scale(1.45)' }, { transform: 'scale(1)' }],
+        { duration: 700, easing: SPRING },
+      );
+    }
+  });
+};
 
 const onScroll = () => {
   const y = window.scrollY;
@@ -64,11 +126,17 @@ const isOverlay = computed(() => !!props.overlay && !scrolled.value);
       "
     >
       <div class="mx-auto flex h-16 w-full max-w-6xl items-center justify-between gap-4 px-6">
-        <a href="/" class="site-logo flex shrink-0 items-center gap-2.5" aria-label="RNP home">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 275.37 167.48" class="h-7 w-auto" aria-hidden="true">
-            <path fill="#ffdc4a" d="M95.79,83.73a95.44,95.44,0,0,1,31.82-71.27,83.73,83.73,0,1,0,0,142.54A95.44,95.44,0,0,1,95.79,83.73Z" transform="translate(0.08 0.01)" />
-            <path fill="#1a7bec" d="M179.46,83.73A95.44,95.44,0,0,1,147.6,155a83.73,83.73,0,1,0,0-142.54A95.44,95.44,0,0,1,179.46,83.73Z" transform="translate(0.08 0.01)" />
-            <path fill="#00dfb7" d="M167.49,83.73a83.57,83.57,0,0,0-29.87-64,83.59,83.59,0,0,0,0,128.09A83.57,83.57,0,0,0,167.49,83.73Z" transform="translate(0.08 0.01)" />
+        <a
+          href="/"
+          class="site-logo flex shrink-0 items-center gap-2.5"
+          aria-label="RNP home"
+          @click="onLogoClick"
+          @mouseenter="onLogoEnter"
+        >
+          <svg ref="logoSvg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 275.37 167.48" class="h-7 w-auto" aria-hidden="true">
+            <path class="lens" fill="#ffdc4a" d="M95.79,83.73a95.44,95.44,0,0,1,31.82-71.27,83.73,83.73,0,1,0,0,142.54A95.44,95.44,0,0,1,95.79,83.73Z" transform="translate(0.08 0.01)" />
+            <path class="lens" fill="#1a7bec" d="M179.46,83.73A95.44,95.44,0,0,1,147.6,155a83.73,83.73,0,1,0,0-142.54A95.44,95.44,0,0,1,179.46,83.73Z" transform="translate(0.08 0.01)" />
+            <path class="lens" fill="#00dfb7" d="M167.49,83.73a83.57,83.57,0,0,0-29.87-64,83.59,83.59,0,0,0,0,128.09A83.57,83.57,0,0,0,167.49,83.73Z" transform="translate(0.08 0.01)" />
           </svg>
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 387.41 172.4" class="h-[1.35rem] w-auto" fill="currentColor" aria-label="rnp">
             <path d="M27.3,3.19,29.48,17C38.67,2.23,51,0,63.12,0S87.33,4.84,93.86,11.38L80.55,37.08a29.5,29.5,0,0,0-21.31-7.74c-15.5,0-29.71,8.23-29.71,30.27v62.92H0V3.19Z" />
@@ -175,5 +243,9 @@ const isOverlay = computed(() => !!props.overlay && !scrolled.value);
 .fade-enter-from,
 .fade-leave-to {
   opacity: 0;
+}
+.lens {
+  transform-box: fill-box;
+  transform-origin: center;
 }
 </style>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -3,6 +3,7 @@ import '../styles/global.css';
 import { ClientRouter } from 'astro:transitions';
 import SiteHeader from '../components/vue/SiteHeader.vue';
 import SiteSearch from '../components/vue/SiteSearch.vue';
+import EasterEggs from '../components/vue/EasterEggs.vue';
 import SiteFooter from '../components/SiteFooter.astro';
 
 interface Props {
@@ -118,5 +119,6 @@ const jsonLd = {
     </main>
     <SiteFooter />
     <SiteSearch client:only="vue" />
+    <EasterEggs client:load />
   </body>
 </html>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -36,12 +36,17 @@ const releaseDate = release.publishedAt.slice(0, 10);
   <!-- ============ HERO ============ -->
   <section class="hero-gradient relative overflow-hidden text-white">
     <div class="hero-grid absolute inset-0" aria-hidden="true"></div>
-    <img
-      src="/assets/brand/symbol.svg"
-      alt=""
+    <div
+      class="pointer-events-none absolute -right-40 top-1/2 hidden w-[30rem] -translate-y-1/2 lg:block"
       aria-hidden="true"
-      class="pointer-events-none absolute -right-40 top-1/2 hidden w-[30rem] -translate-y-1/2 opacity-[0.14] blur-[1px] lg:block dark:opacity-[0.09]"
-    />
+    >
+      <img
+        data-hero-watermark
+        src="/assets/brand/symbol.svg"
+        alt=""
+        class="w-full opacity-[0.14] blur-[1px] dark:opacity-[0.09]"
+      />
+    </div>
     <div class="relative mx-auto w-full max-w-6xl px-6 pb-16 pt-28 md:pb-24 md:pt-36">
       <div class="grid items-center gap-12 lg:grid-cols-[1.15fr_1fr]">
         <div>
@@ -269,3 +274,14 @@ const releaseDate = release.publishedAt.slice(0, 10);
     </div>
   </section>
 </BaseLayout>
+
+<script>
+  // Scroll-driven WAAPI: the hero watermark slowly rotates as you scroll past it.
+  const wm = document.querySelector('[data-hero-watermark]');
+  if (wm && 'ScrollTimeline' in window && !matchMedia('(prefers-reduced-motion: reduce)').matches) {
+    wm.animate([{ transform: 'rotate(0deg)' }, { transform: 'rotate(32deg)' }], {
+      timeline: new ScrollTimeline({ source: document.scrollingElement ?? document.documentElement }),
+      fill: 'both',
+    });
+  }
+</script>


### PR DESCRIPTION
## What's in it

**WAAPI with the RNP logo:**
- Header logo on the home page: hover wobble, springy click pulse — and every **3rd click** triggers the *ribosome shuffle*: the vesica's two outer lenses split apart and snap back while the center lens pulses (all native Web Animations API, spring easing)
- The hero watermark symbol now rotates slowly on scroll via `ScrollTimeline` (graceful no-op where unsupported)

**Hidden fun:**
- **Konami code** (↑↑↓↓←→←→BA) summons a brand-colored hex rain (blue/teal/gold on dark canvas, WAAPI fade in/out) ending with an "Entropy acquired ✓" toast
- Typing **`decrypt`** anywhere replays the hero's scramble animation

Everything respects `prefers-reduced-motion` (toast fallbacks instead of animation), and everything is covered by automated checks: the e2e suite grew to **25 checks** (WAAPI animation probes via `document.getAnimations()`, Konami sequence, typing trigger) — all passing locally. One real fix included: the hero replay listener is now registered even in reduced-motion environments.