### PR TITLE
Simpler easter egg trigger: type 'rnp' or 'pgp'

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,10 +110,10 @@ There is no unit test suite; validation is building + link checking.
   forces it, so test checks must accept both paths.
 - **WAAPI easter eggs** (keep them working, don't spoil them in visible copy):
   header logo on the home page — hover wobble, click pulse, every 3rd click is
-  the "ribosome shuffle" (lenses split and snap back); Konami code summons a
-  brand-colored hex rain; typing `decrypt` replays the hero scramble; the hero
-  watermark rotates on scroll via `ScrollTimeline`. All are covered by
-  `scripts/e2e-cdp.mjs` (25 checks).
+  the "ribosome shuffle" (lenses split and snap back); typing `rnp` or `pgp`
+  summons a brand-colored hex rain; typing `decrypt` replays the hero
+  scramble; the hero watermark rotates on scroll via `ScrollTimeline`. All are
+  covered by `scripts/e2e-cdp.mjs` (26 checks).
 - **Search**: Pagefind index is generated post-build (`pagefind --site dist`);
   the `SiteSearch` island loads `/pagefind/pagefind.js` at runtime (absent in
   plain `astro dev`).

--- a/scripts/e2e-cdp.mjs
+++ b/scripts/e2e-cdp.mjs
@@ -156,10 +156,18 @@ await evaluate(`document.querySelector('.site-logo')?.click(); document.querySel
 await sleep(250);
 check('home: triple-click triggers the ribosome shuffle', (await evaluate(`document.getAnimations().length > 0`)) === true);
 
-await evaluate(`['ArrowUp','ArrowUp','ArrowDown','ArrowDown','ArrowLeft','ArrowRight','ArrowLeft','ArrowRight','b','a'].forEach(k => window.dispatchEvent(new KeyboardEvent('keydown', { key: k })))`);
+await evaluate(`'rnp'.split('').forEach(k => window.dispatchEvent(new KeyboardEvent('keydown', { key: k })))`);
 await sleep(600);
 check(
-  'home: Konami code triggers the egg (canvas rain, or toast when reduced-motion)',
+  'home: typing "rnp" triggers the egg (canvas rain, or toast when reduced-motion)',
+  (await evaluate(`!!document.querySelector('canvas[aria-hidden="true"]') || (document.querySelector('[role="status"]')?.textContent ?? '').includes('Entropy acquired')`)) === true,
+);
+await sleep(3400);
+
+await evaluate(`'pgp'.split('').forEach(k => window.dispatchEvent(new KeyboardEvent('keydown', { key: k })))`);
+await sleep(600);
+check(
+  'home: typing "pgp" also triggers the egg',
   (await evaluate(`!!document.querySelector('canvas[aria-hidden="true"]') || (document.querySelector('[role="status"]')?.textContent ?? '').includes('Entropy acquired')`)) === true,
 );
 await sleep(3400);

--- a/src/components/vue/EasterEggs.vue
+++ b/src/components/vue/EasterEggs.vue
@@ -25,20 +25,7 @@ watch(toastMsg, async (msg) => {
   );
 });
 
-/* ---- Konami code → brand-colored hex rain (WAAPI + canvas) ---- */
-const KONAMI = [
-  'arrowup',
-  'arrowup',
-  'arrowdown',
-  'arrowdown',
-  'arrowleft',
-  'arrowright',
-  'arrowleft',
-  'arrowright',
-  'b',
-  'a',
-];
-let seq: string[] = [];
+/* ---- Secret words: type 'rnp' or 'pgp' → brand hex rain; 'decrypt' → replay hero ---- */
 let word = '';
 
 const hexRain = () => {
@@ -103,22 +90,19 @@ const onKey = (e: KeyboardEvent) => {
   const t = e.target as HTMLElement | null;
   if (t && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable)) return;
   const k = e.key.toLowerCase();
-
-  seq.push(k);
-  if (seq.length > KONAMI.length) seq.shift();
-  if (seq.join(',') === KONAMI.join(',')) {
-    seq = [];
-    hexRain();
+  if (!/^[a-z]$/.test(k)) {
+    word = '';
     return;
   }
 
-  if (/^[a-z]$/.test(k)) {
-    word = (word + k).slice(-12);
-    if (word.endsWith('decrypt')) {
-      word = '';
-      window.dispatchEvent(new CustomEvent('rnp:replay-hero'));
-      toast('Replaying decryption…');
-    }
+  word = (word + k).slice(-12);
+  if (word.endsWith('decrypt')) {
+    word = '';
+    window.dispatchEvent(new CustomEvent('rnp:replay-hero'));
+    toast('Replaying decryption…');
+  } else if (word.endsWith('rnp') || word.endsWith('pgp')) {
+    word = '';
+    hexRain();
   }
 };
 


### PR DESCRIPTION
Konami was too long — now typing **`rnp`** or **`pgp`** anywhere on the site summons the brand-colored hex rain (`decrypt` still replays the hero scramble).

Details: the letter accumulator resets on any non-letter key and ignores input/textarea/contenteditable targets, so it won't fire while people type into the search box or the fingerprint playground. Both words are covered by the e2e suite (26/26 locally).