### PR TITLE
Scope reduced-motion to passive animation only

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,8 +106,9 @@ There is no unit test suite; validation is building + link checking.
 - **Imports**: use the `@/` alias (`@/components/...`, `@/layouts/...`).
 - **Islands**: interactivity goes in Vue SFCs under `src/components/vue/`,
   hydrated with `client:visible` (below the fold) or `client:load`; props must
-  be JSON-serializable. Respect `prefers-reduced-motion` — headless Chrome
-  forces it, so test checks must accept both paths.
+  be JSON-serializable. `prefers-reduced-motion` gates **passive** animation
+  only (auto-play, scroll-driven) — never user-triggered animation the
+  visitor explicitly asked for (eggs, logo play, replays).
 - **WAAPI easter eggs** (keep them working, don't spoil them in visible copy):
   header logo on the home page — hover wobble, click pulse, every 3rd click is
   the "ribosome shuffle" (lenses split and snap back); typing `rnp` or `pgp`

--- a/scripts/e2e-cdp.mjs
+++ b/scripts/e2e-cdp.mjs
@@ -159,24 +159,27 @@ check('home: triple-click triggers the ribosome shuffle', (await evaluate(`docum
 await evaluate(`'rnp'.split('').forEach(k => window.dispatchEvent(new KeyboardEvent('keydown', { key: k })))`);
 await sleep(600);
 check(
-  'home: typing "rnp" triggers the egg (canvas rain, or toast when reduced-motion)',
-  (await evaluate(`!!document.querySelector('canvas[aria-hidden="true"]') || (document.querySelector('[role="status"]')?.textContent ?? '').includes('Entropy acquired')`)) === true,
+  'home: typing "rnp" summons the hex rain canvas (user-triggered, always plays)',
+  (await evaluate(`!!document.querySelector('canvas[aria-hidden="true"]')`)) === true,
 );
 await sleep(3400);
 
 await evaluate(`'pgp'.split('').forEach(k => window.dispatchEvent(new KeyboardEvent('keydown', { key: k })))`);
 await sleep(600);
 check(
-  'home: typing "pgp" also triggers the egg',
-  (await evaluate(`!!document.querySelector('canvas[aria-hidden="true"]') || (document.querySelector('[role="status"]')?.textContent ?? '').includes('Entropy acquired')`)) === true,
+  'home: typing "pgp" also summons the hex rain',
+  (await evaluate(`!!document.querySelector('canvas[aria-hidden="true"]')`)) === true,
 );
 await sleep(3400);
 
+const heroSpanSel = '.hero-decrypt';
 await evaluate(`'decrypt'.split('').forEach(k => window.dispatchEvent(new KeyboardEvent('keydown', { key: k })))`);
 await sleep(500);
 check(
-  'home: typing "decrypt" replays the hero scramble',
-  (await evaluate(`(document.querySelector('[role="status"]')?.textContent ?? '').includes('Replaying decryption')`)) === true,
+  'home: typing "decrypt" replays the hero scramble (user-triggered, always plays)',
+  (await evaluate(`(document.querySelector('[role="status"]')?.textContent ?? '').includes('Replaying decryption')`)) === true &&
+    (await evaluate(`document.querySelector('${heroSpanSel}')?.textContent ?? ''`)) !==
+      'Powering end-to-end email encryption in',
 );
 await sleep(1500);
 

--- a/src/components/vue/EasterEggs.vue
+++ b/src/components/vue/EasterEggs.vue
@@ -5,8 +5,6 @@ const toastMsg = ref('');
 const toastEl = ref<HTMLElement | null>(null);
 let toastTimer: ReturnType<typeof setTimeout> | undefined;
 
-const reducedMotion = () => matchMedia('(prefers-reduced-motion: reduce)').matches;
-
 const toast = (msg: string) => {
   toastMsg.value = msg;
   clearTimeout(toastTimer);
@@ -29,10 +27,8 @@ watch(toastMsg, async (msg) => {
 let word = '';
 
 const hexRain = () => {
-  if (reducedMotion()) {
-    toast('Entropy acquired ✓');
-    return;
-  }
+  // User-initiated (typed a secret word): always play — prefers-reduced-motion
+  // only governs passive animation, never something the user asked for.
   const canvas = document.createElement('canvas');
   canvas.className = 'pointer-events-none fixed inset-0 z-[90]';
   canvas.setAttribute('aria-hidden', 'true');

--- a/src/components/vue/HeroDecrypt.vue
+++ b/src/components/vue/HeroDecrypt.vue
@@ -30,18 +30,18 @@ const run = () => {
   raf = requestAnimationFrame(tick);
 };
 
-const maybeRun = () => {
-  if (!matchMedia('(prefers-reduced-motion: reduce)').matches) run();
-};
+const reducedMotion = () => matchMedia('(prefers-reduced-motion: reduce)').matches;
 
 onMounted(() => {
-  maybeRun();
-  window.addEventListener('rnp:replay-hero', maybeRun);
+  // Passive auto-play respects reduced-motion…
+  if (!reducedMotion()) run();
+  // …but a user explicitly typing 'decrypt' always gets the replay.
+  window.addEventListener('rnp:replay-hero', run);
 });
 
 onUnmounted(() => {
   cancelAnimationFrame(raf);
-  window.removeEventListener('rnp:replay-hero', maybeRun);
+  window.removeEventListener('rnp:replay-hero', run);
 });
 </script>
 

--- a/src/components/vue/SiteHeader.vue
+++ b/src/components/vue/SiteHeader.vue
@@ -23,12 +23,12 @@ let lastY = 0;
 let clickCount = 0;
 let clickTimer: ReturnType<typeof setTimeout> | undefined;
 
-const reducedMotion = () => matchMedia('(prefers-reduced-motion: reduce)').matches;
 const SPRING = 'cubic-bezier(.22, 1.4, .36, 1)';
 
-/** WAAPI logo play: wobble on hover, pulse per click, lens-shuffle every 3rd. */
+/** WAAPI logo play: wobble on hover, pulse per click, lens-shuffle every 3rd.
+ *  User-initiated, so it plays regardless of prefers-reduced-motion. */
 const onLogoEnter = () => {
-  if (!logoSvg.value || reducedMotion()) return;
+  if (!logoSvg.value) return;
   logoSvg.value.animate(
     [
       { transform: 'rotate(0deg)' },
@@ -43,7 +43,7 @@ const onLogoEnter = () => {
 const onLogoClick = (e: MouseEvent) => {
   if (props.currentPath !== '/') return; // normal navigation elsewhere
   e.preventDefault();
-  if (reducedMotion() || !logoSvg.value) return;
+  if (!logoSvg.value) return;
   clickCount++;
   clearTimeout(clickTimer);
   clickTimer = setTimeout(() => (clickCount = 0), 900);


### PR DESCRIPTION
Sharp call: `prefers-reduced-motion` is about *unsolicited* motion, not about animation the user explicitly invokes.

**Now gated by reduced-motion (passive):** initial hero decrypt on page load, scroll reveals, scroll-linked watermark rotation.

**Always plays (user asked for it):** the hex rain from typing `rnp`/`pgp`, logo hover/click/shuffle, hero replay from typing `decrypt`.

This also fixed the e2e checks to assert the stronger behavior: the rain must fire even in headless Chrome (which forces reduced-motion). 26/26 locally.