### PR TITLE
Oracle rain: characters rain down in random order

### DIFF
--- a/scripts/e2e-cdp.mjs
+++ b/scripts/e2e-cdp.mjs
@@ -162,7 +162,7 @@ check(
   'home: typing "rnp" summons the oracle rain canvas (user-triggered, always plays)',
   (await evaluate(`!!document.querySelector('canvas[aria-hidden="true"]')`)) === true,
 );
-await sleep(4800); // converge + hover + dissolve → toast at ~5.1s
+await sleep(6200); // falls + hover + dissolve → toast at ~6.5s
 check(
   'home: the rain resolves into an ancient quote',
   (await evaluate(`(document.querySelector('[role="status"]')?.textContent ?? '').includes('—')`)) === true,
@@ -184,7 +184,7 @@ check(
   'home: typing "pgp" also summons the oracle rain',
   (await evaluate(`!!document.querySelector('canvas[aria-hidden="true"]')`)) === true,
 );
-await sleep(4800);
+await sleep(6200);
 check(
   'home: the second rain resolves into a quote too',
   (await evaluate(`(document.querySelector('[role="status"]')?.textContent ?? '').includes('—')`)) === true,

--- a/src/components/vue/EasterEggs.vue
+++ b/src/components/vue/EasterEggs.vue
@@ -126,10 +126,18 @@ const hexRain = () => {
   });
   const midY = canvas.height / 2;
 
-  /* Phases: pour → converge → hover (linger) → dissolve. */
-  const POUR = 2600;
-  const CONVERGE = 3400;
-  const LINGER = 4600;
+  /* Phases: pour → chars rain down one by one in random order → hover → dissolve. */
+  const order = chars.map((_, i) => i);
+  for (let i = order.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [order[i], order[j]] = [order[j], order[i]];
+  }
+  const POUR = 2400;
+  const STEP = Math.max(55, Math.min(150, 1800 / chars.length));
+  const FALL = 550;
+  const lastLand = POUR + STEP * (chars.length - 1) + FALL;
+  const LINGER = lastLand + 1300;
+  const easeOutCubic = (p: number) => 1 - Math.pow(1 - p, 3);
   const start = performance.now();
   let raf = 0;
   canvas.animate([{ opacity: 0 }, { opacity: 1 }], { duration: 250, fill: 'forwards' });
@@ -158,28 +166,35 @@ const hexRain = () => {
   const drawMessage = (t: number) => {
     ctx.font = `700 ${msgSize}px "IBM Plex Mono", "PingFang SC", "Noto Sans CJK SC", monospace`;
     ctx.textBaseline = 'middle';
-    for (let i = 0; i < targets.length; i++) {
-      const reveal = Math.min(1, Math.max(0, (t - (POUR + i * 55)) / 320));
-      if (reveal <= 0) continue;
-      // characters hover gently once fully formed
-      const hover = t > CONVERGE ? Math.sin((t + i * 140) / 420) * 2.5 : 0;
-      ctx.globalAlpha = reveal;
+    for (let k = 0; k < order.length; k++) {
+      const i = order[k];
+      const startT = POUR + k * STEP;
+      const p = Math.min(1, Math.max(0, (t - startT) / FALL));
+      if (p <= 0) continue;
+      // the character rains down from above to its slot, then stays
+      const y = p < 1 ? lerpY(-40 - ((i * 37) % 180), midY, easeOutCubic(p)) : midY;
+      const hover = p >= 1 && t > lastLand ? Math.sin((t + i * 140) / 420) * 2.5 : 0;
+      ctx.globalAlpha = Math.min(1, p * 1.8);
       ctx.fillStyle = '#ffdc4a';
       ctx.shadowColor = '#ffdc4a';
-      ctx.shadowBlur = 14 * reveal;
-      ctx.fillText(targets[i].c, targets[i].x, midY + hover);
+      ctx.shadowBlur = 14 * p;
+      ctx.fillText(targets[i].c, targets[i].x, y + hover);
     }
     ctx.globalAlpha = 1;
     ctx.shadowBlur = 0;
     ctx.textBaseline = 'alphabetic';
   };
+  const lerpY = (a: number, b: number, p: number) => a + (b - a) * p;
 
   const tick = (now: number) => {
     const t = now - start;
-    if (t < CONVERGE) {
-      drawRain(t, t < POUR ? 1 : 0.22, t < POUR ? 0.14 : 0.3);
+    if (t < lastLand) {
+      // ambient rain fades out while the message chars land
+      const dim =
+        t < POUR ? 1 : Math.max(0.05, 0.22 * (1 - (t - POUR) / Math.max(1, lastLand - POUR)));
+      drawRain(t, t < POUR ? 1 : dim, t < POUR ? 0.14 : 0.3);
     } else {
-      drawRain(t, 0.09, 0.34);
+      drawRain(t, 0.05, 0.4); // rain gone — the message stands clear
     }
     if (t >= POUR) drawMessage(t);
 


### PR DESCRIPTION
Per request, the final sentence is now *formed by rain itself*:

- After the pour, each character of the quote **falls from above into its slot — one by one in shuffled, random order**, glowing gold as it lands
- The ambient rain **dims away progressively** as the characters land, so the message ends up standing clear in the middle
- Fall cadence adapts to message length (PANTA RHEI's 10 chars land deliberately; the butterfly's 35 cascade quickly)
- The gentle sine hover only begins after the last character lands, then the usual dissolve + attributed toast

Captured mid-fall for review: landed gold chars at center, more glowing in flight around them, ambient rain dimming behind. e2e **29/29**.