### PR TITLE
Make Cmd+K search work in astro dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 node_modules/
 dist/
 .astro/
+# Dev-only Pagefind index copy (prepare-dev-search.mjs)
+public/pagefind/
 # Pulled-in software sources (fetch-sources.mjs)
 vendor/
 # Legacy Jekyll-era artifacts (never recommit)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,8 +120,10 @@ There is no unit test suite; validation is building + link checking.
   scramble; the hero watermark rotates on scroll via `ScrollTimeline`. All are
   covered by `scripts/e2e-cdp.mjs` (28 checks).
 - **Search**: Pagefind index is generated post-build (`pagefind --site dist`);
-  the `SiteSearch` island loads `/pagefind/pagefind.js` at runtime (absent in
-  plain `astro dev`).
+  the `SiteSearch` island loads `/pagefind/pagefind.js` at runtime. In dev,
+  `predev` copies the latest built index to `public/pagefind/` (gitignored) via
+  `scripts/prepare-dev-search.mjs` — run `npm run build` once after checkout
+  for search to work in `astro dev`.
 - **Dead links**: when an external link dies, point it at a Wayback Machine
   snapshot (`https://archive.org/wayback/available?url=<url>&timestamp=<yyyymmdd>`
   finds the closest capture) instead of a substitute page — the snapshot

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "predev": "node scripts/fetch-sources.mjs",
+    "predev": "node scripts/fetch-sources.mjs && node scripts/prepare-dev-search.mjs",
     "prebuild": "node scripts/fetch-sources.mjs",
     "postbuild": "pagefind --site dist",
     "fetch-sources": "node scripts/fetch-sources.mjs",

--- a/scripts/prepare-dev-search.mjs
+++ b/scripts/prepare-dev-search.mjs
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+/**
+ * Makes search work in `astro dev`: the Pagefind index is generated from the
+ * production build (postbuild → dist/pagefind), which the dev server doesn't
+ * serve. This copies the latest built index into public/pagefind (gitignored)
+ * so the dev server can serve it. Run after a build; predev runs it for you.
+ */
+import { cpSync, existsSync, rmSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const src = join(root, 'dist', 'pagefind');
+const dest = join(root, 'public', 'pagefind');
+
+if (!existsSync(join(src, 'pagefind.js'))) {
+  console.warn(
+    '[prepare-dev-search] no build index found at dist/pagefind — ' +
+      'run `npm run build` once; search will be unavailable in dev until then.',
+  );
+  process.exit(0);
+}
+
+rmSync(dest, { recursive: true, force: true });
+cpSync(src, dest, { recursive: true });
+console.log('[prepare-dev-search] copied dist/pagefind → public/pagefind (dev search ready)');


### PR DESCRIPTION
The search kept saying *'Search index not found. Run npm run build to generate it.'* in dev — Pagefind only indexes the built site, and `astro dev` had nothing to serve.

**Fix:** `predev` now runs `scripts/prepare-dev-search.mjs`, which copies the latest built index (`dist/pagefind`) into `public/pagefind/` (gitignored) so the dev server serves it too. If no build exists yet it warns and continues gracefully.

Verified against a running dev server: `/pagefind/pagefind.js` went 404 → **200 without a restart** (astro dev serves `public/` live). One `npm run build` after checkout keeps dev search working thereafter; the note is in AGENTS.md.