### PR TITLE
Point signing-keys docs at our OpenPGP keys page

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -113,7 +113,10 @@ const UPSTREAM_LINK_FIXES: [string, string][] = [
 const softwareDocs = defineCollection({
   loader: adocLoader({
     base: './vendor',
-    include: (rel) => /^[^/]+\/(README\.adoc|docs\/.+\.adoc)$/.test(rel),
+    // signing-keys.adoc is excluded: signing keys live on our own /openpgp_keys/ page.
+    include: (rel) =>
+      /^[^/]+\/(README\.adoc|docs\/.+\.adoc)$/.test(rel) &&
+      !rel.endsWith('docs/signing-keys.adoc'),
     idFromRel: (rel) => {
       const parts = rel.split('/');
       const product = parts[0];

--- a/src/layouts/DocsLayout.astro
+++ b/src/layouts/DocsLayout.astro
@@ -41,7 +41,7 @@ const { title, description, product, productTitle, docs, currentSlug } = Astro.p
             {
               docs.map((doc) => (
                 <a
-                  href={`/software/${product}/docs/${doc.slug}/`}
+                  href={doc.slug.startsWith('/') ? doc.slug : `/software/${product}/docs/${doc.slug}/`}
                   class:list={[
                     'block rounded-md px-3 py-2 font-sans text-sm transition-colors',
                     doc.slug.includes('/') && 'pl-6',

--- a/src/pages/software/[id].astro
+++ b/src/pages/software/[id].astro
@@ -29,6 +29,10 @@ const docs = (await getCollection('softwareDocs'))
   .filter((d) => d.data.product === entry.id)
   .map((d) => ({ slug: d.id.split('/').slice(1).join('/'), title: d.data.title }))
   .sort((a, b) => docSort(a.slug, b.slug));
+// Signing keys live on the site's own OpenPGP keys page, not in the repo docs.
+if (entry.id === 'rnp') {
+  docs.push({ slug: '/openpgp_keys/', title: 'PGP keys used for signing source code ↗' });
+}
 ---
 
 <BaseLayout title={data.title} description={data.description}>
@@ -91,7 +95,7 @@ const docs = (await getCollection('softwareDocs'))
               <nav class="mt-4">
                 {docs.map((doc) => (
                   <a
-                    href={`/software/${entry.id}/docs/${doc.slug}/`}
+                    href={doc.slug.startsWith('/') ? doc.slug : `/software/${entry.id}/docs/${doc.slug}/`}
                     class="block py-1.5 font-sans text-sm text-muted transition-colors hover:text-accent"
                   >
                     {doc.title}

--- a/src/pages/software/[product]/docs/[...slug].astro
+++ b/src/pages/software/[product]/docs/[...slug].astro
@@ -36,6 +36,10 @@ const docs = (await getCollection('softwareDocs'))
   .filter((d) => d.data.product === product)
   .map((d) => ({ slug: d.id.split('/').slice(1).join('/'), title: d.data.title }))
   .sort((a, b) => docSort(a.slug, b.slug));
+// Signing keys live on the site's own OpenPGP keys page, not in the repo docs.
+if (product === 'rnp') {
+  docs.push({ slug: '/openpgp_keys/', title: 'PGP keys used for signing source code ↗' });
+}
 
 const { Content } = await render(entry);
 ---

--- a/src/pages/software/rnp/docs/signing-keys/index.astro
+++ b/src/pages/software/rnp/docs/signing-keys/index.astro
@@ -1,0 +1,32 @@
+---
+// The upstream signing-keys doc is superseded by our own OpenPGP keys page.
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="robots" content="noindex" />
+    <meta http-equiv="refresh" content="0; url=/openpgp_keys/" />
+    <link rel="canonical" href="https://www.rnpgp.org/openpgp_keys/" />
+    <title>Moved — RNP</title>
+    <style>
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        font-family: ui-monospace, monospace;
+        background: #f8fbfe;
+        color: #23273a;
+      }
+      a {
+        color: #1a7bec;
+      }
+    </style>
+  </head>
+  <body>
+    <p>This page has moved — <a href="/openpgp_keys/">OpenPGP keys</a></p>
+  </body>
+</html>


### PR DESCRIPTION
Per review: the embedded upstream `signing-keys` doc duplicated what `/openpgp_keys/` already does better.

- **Upstream doc excluded** from the build (vendor content stays untouched)
- **Old URL preserved**: `/software/rnp/docs/signing-keys/` is now a redirect stub → `/openpgp_keys/` (inbound links from the old site and from other docs keep working)
- **Both docs sidebars** (product page + DocsLayout) now list *PGP keys used for signing source code* as an off-docs link (↗) to the keys page

Internal link check clean, e2e **29/29**.