### PR TITLE
Hyphenate the OpenPGP keys route

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,7 +154,10 @@ There is no unit test suite; validation is building + link checking.
 - Old blog URLs (`/blog/DD-MM-YYYY/slug/`) are redirect pages generated from
   posts' `redirect_from` front matter — keep that field when touching old posts.
 - The `openpgp_keys/*.asc` files are release-signing keys; treat them as
-  immutable unless a key actually rotates.
+  immutable unless a key actually rotates. The keys *page* is
+  `/openpgp-keys/` (hyphenated); the legacy `/openpgp_keys/` URL redirects
+  there, while the `.asc` files keep the underscore prefix so published
+  key-file URLs stay stable.
 - Man-page/description strings in `src/content.config.ts` are parsed from the
   AsciiDoc `== NAME` sections — if upstream renames sections, descriptions
   fall back to empty.

--- a/scripts/e2e-cdp.mjs
+++ b/scripts/e2e-cdp.mjs
@@ -305,7 +305,7 @@ check(
 );
 
 /* ---------- OPENPGP KEYS ---------- */
-await navigate(`${BASE}/openpgp_keys/`);
+await navigate(`${BASE}/openpgp-keys/`);
 await evaluate(`document.querySelector('.fingerprint')?.scrollIntoView({ block: 'center' })`);
 await sleep(1000);
 const keyFp = await evaluate(`document.querySelector('.fingerprint')?.textContent ?? ''`);

--- a/src/components/SiteFooter.astro
+++ b/src/components/SiteFooter.astro
@@ -30,7 +30,7 @@ const columns = [
     links: [
       { href: '/docs/', label: 'Manual' },
       { href: '/advisories/', label: 'Security advisories' },
-      { href: '/openpgp_keys/', label: 'OpenPGP keys' },
+      { href: '/openpgp-keys/', label: 'OpenPGP keys' },
       { href: '/rss.xml', label: 'RSS feed' },
       { href: 'https://www.ribose.com/tos', label: 'Terms of service', external: true },
       { href: 'https://www.ribose.com/privacy', label: 'Privacy policy', external: true },

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -113,7 +113,7 @@ const UPSTREAM_LINK_FIXES: [string, string][] = [
 const softwareDocs = defineCollection({
   loader: adocLoader({
     base: './vendor',
-    // signing-keys.adoc is excluded: signing keys live on our own /openpgp_keys/ page.
+    // signing-keys.adoc is excluded: signing keys live on our own /openpgp-keys/ page.
     include: (rel) =>
       /^[^/]+\/(README\.adoc|docs\/.+\.adoc)$/.test(rel) &&
       !rel.endsWith('docs/signing-keys.adoc'),

--- a/src/pages/openpgp-keys.astro
+++ b/src/pages/openpgp-keys.astro
@@ -1,0 +1,36 @@
+---
+import BaseLayout from '@/layouts/BaseLayout.astro';
+import PageHero from '@/components/PageHero.astro';
+import KeyFingerprintCards from '@/components/vue/KeyFingerprintCards.vue';
+
+const keys = [
+  {
+    fingerprint: '31AF5A24D861EFCB7CB79A1924900CE0AEFB5417',
+    keyId: '24900CE0AEFB5417',
+    userId: 'RNPGP Release Signing Key <rnpgp@ribose.com>',
+    // NOTE: .asc key files intentionally keep the legacy /openpgp_keys/ prefix
+    // — published key-file URLs must stay stable. Only the page moved.
+    file: '/openpgp_keys/31AF5A24D861EFCB7CB79A1924900CE0AEFB5417-50DA59D5B9134FA2DB1EB20CFB829AB5D0FE017F.asc',
+    current: true,
+  },
+  {
+    fingerprint: 'BEDBA05C1E6EE2DFB4BA72E1EC5D520AD90A7262',
+    keyId: 'EC5D520AD90A7262',
+    userId: 'RNPGP Release Signing Key <rnpgp@ribose.com>',
+    file: '/openpgp_keys/BEDBA05C1E6EE2DFB4BA72E1EC5D520AD90A7262-A845A5BD622556E89D7763B5EB06D1696BEC4C90.asc',
+    current: false,
+  },
+];
+---
+
+<BaseLayout title="OpenPGP keys" description="OpenPGP keys used to sign RNP releases.">
+  <PageHero
+    eyebrow="Security — OpenPGP keys"
+    title="OpenPGP keys"
+    description="The following key is used to sign source code packages of RNP releases."
+  />
+
+  <section class="mx-auto w-full max-w-3xl px-6 py-16 md:py-20">
+    <KeyFingerprintCards client:visible keys={keys} />
+  </section>
+</BaseLayout>

--- a/src/pages/openpgp_keys.astro
+++ b/src/pages/openpgp_keys.astro
@@ -1,34 +1,32 @@
 ---
-import BaseLayout from '@/layouts/BaseLayout.astro';
-import PageHero from '@/components/PageHero.astro';
-import KeyFingerprintCards from '@/components/vue/KeyFingerprintCards.vue';
-
-const keys = [
-  {
-    fingerprint: '31AF5A24D861EFCB7CB79A1924900CE0AEFB5417',
-    keyId: '24900CE0AEFB5417',
-    userId: 'RNPGP Release Signing Key <rnpgp@ribose.com>',
-    file: '/openpgp_keys/31AF5A24D861EFCB7CB79A1924900CE0AEFB5417-50DA59D5B9134FA2DB1EB20CFB829AB5D0FE017F.asc',
-    current: true,
-  },
-  {
-    fingerprint: 'BEDBA05C1E6EE2DFB4BA72E1EC5D520AD90A7262',
-    keyId: 'EC5D520AD90A7262',
-    userId: 'RNPGP Release Signing Key <rnpgp@ribose.com>',
-    file: '/openpgp_keys/BEDBA05C1E6EE2DFB4BA72E1EC5D520AD90A7262-A845A5BD622556E89D7763B5EB06D1696BEC4C90.asc',
-    current: false,
-  },
-];
+// Legacy underscore URL — the page lives at /openpgp-keys/ now.
 ---
 
-<BaseLayout title="OpenPGP keys" description="OpenPGP keys used to sign RNP releases.">
-  <PageHero
-    eyebrow="Security — OpenPGP keys"
-    title="OpenPGP keys"
-    description="The following key is used to sign source code packages of RNP releases."
-  />
-
-  <section class="mx-auto w-full max-w-3xl px-6 py-16 md:py-20">
-    <KeyFingerprintCards client:visible keys={keys} />
-  </section>
-</BaseLayout>
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="robots" content="noindex" />
+    <meta http-equiv="refresh" content="0; url=/openpgp-keys/" />
+    <link rel="canonical" href="https://www.rnpgp.org/openpgp-keys/" />
+    <title>Moved — RNP</title>
+    <style>
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        font-family: ui-monospace, monospace;
+        background: #f8fbfe;
+        color: #23273a;
+      }
+      a {
+        color: #1a7bec;
+      }
+    </style>
+  </head>
+  <body>
+    <p>This page has moved — <a href="/openpgp-keys/">OpenPGP keys</a></p>
+  </body>
+</html>

--- a/src/pages/software/[id].astro
+++ b/src/pages/software/[id].astro
@@ -31,7 +31,7 @@ const docs = (await getCollection('softwareDocs'))
   .sort((a, b) => docSort(a.slug, b.slug));
 // Signing keys live on the site's own OpenPGP keys page, not in the repo docs.
 if (entry.id === 'rnp') {
-  docs.push({ slug: '/openpgp_keys/', title: 'PGP keys used for signing source code ↗' });
+  docs.push({ slug: '/openpgp-keys/', title: 'PGP keys used for signing source code ↗' });
 }
 ---
 

--- a/src/pages/software/[product]/docs/[...slug].astro
+++ b/src/pages/software/[product]/docs/[...slug].astro
@@ -38,7 +38,7 @@ const docs = (await getCollection('softwareDocs'))
   .sort((a, b) => docSort(a.slug, b.slug));
 // Signing keys live on the site's own OpenPGP keys page, not in the repo docs.
 if (product === 'rnp') {
-  docs.push({ slug: '/openpgp_keys/', title: 'PGP keys used for signing source code ↗' });
+  docs.push({ slug: '/openpgp-keys/', title: 'PGP keys used for signing source code ↗' });
 }
 
 const { Content } = await render(entry);

--- a/src/pages/software/rnp/docs/signing-keys/index.astro
+++ b/src/pages/software/rnp/docs/signing-keys/index.astro
@@ -8,8 +8,8 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="robots" content="noindex" />
-    <meta http-equiv="refresh" content="0; url=/openpgp_keys/" />
-    <link rel="canonical" href="https://www.rnpgp.org/openpgp_keys/" />
+    <meta http-equiv="refresh" content="0; url=/openpgp-keys/" />
+    <link rel="canonical" href="https://www.rnpgp.org/openpgp-keys/" />
     <title>Moved — RNP</title>
     <style>
       body {
@@ -27,6 +27,6 @@
     </style>
   </head>
   <body>
-    <p>This page has moved — <a href="/openpgp_keys/">OpenPGP keys</a></p>
+    <p>This page has moved — <a href="/openpgp-keys/">OpenPGP keys</a></p>
   </body>
 </html>


### PR DESCRIPTION
Good question — there was no reason for `/openpgp_keys/`; it's a Jekyll-era artifact from the filename `openpgp_keys.adoc`. Hyphens are the URL convention (and Google's guidance).

- Page moved to `/openpgp-keys/`; `/openpgp_keys/` is now a redirect stub (external links to the old URL keep working)
- All internal references updated (footer, both docs sidebars, signing-keys redirect)
- The `.asc` key files deliberately **keep** the underscore prefix — published key-file URLs must not churn (noted in AGENTS.md)

e2e **29/29** (keys check updated to the new route).