### PR TITLE
UX/a11y wins + SEO structured data + full RSS

### DIFF
--- a/src/components/TocNav.astro
+++ b/src/components/TocNav.astro
@@ -1,0 +1,29 @@
+---
+interface Props {
+  toc: { id: string; title: string; level: number }[];
+}
+const { toc } = Astro.props;
+const items = toc.filter((t) => t.level === 2);
+---
+
+{
+  items.length >= 4 && (
+    <nav class="hidden xl:block" aria-label="On this page">
+      <div class="sticky top-24">
+        <p class="mono-label">On this page</p>
+        <ul class="mt-3 space-y-1.5 border-l border-line">
+          {items.map((t) => (
+            <li>
+              <a
+                href={`#${t.id}`}
+                class="-ml-px block border-l-2 border-transparent pl-3 font-sans text-[0.8rem] leading-snug text-faint transition-colors hover:border-accent hover:text-accent"
+              >
+                {t.title}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </nav>
+  )
+}

--- a/src/components/vue/SiteHeader.vue
+++ b/src/components/vue/SiteHeader.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted, ref, watch } from 'vue';
+import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue';
 import ThemeToggle from './ThemeToggle.vue';
 
 const props = defineProps<{ currentPath: string; overlay?: boolean }>();
@@ -91,9 +91,42 @@ const onScroll = () => {
 
 const openSearch = () => window.dispatchEvent(new CustomEvent('rnp:open-search'));
 
-watch(mobileOpen, (open) => {
+const drawerEl = ref<HTMLElement | null>(null);
+let previouslyFocused: HTMLElement | null = null;
+
+watch(mobileOpen, async (open) => {
   document.documentElement.style.overflow = open ? 'hidden' : '';
+  if (open) {
+    previouslyFocused = document.activeElement as HTMLElement | null;
+    await nextTick();
+    drawerEl.value?.querySelector('button')?.focus();
+  } else {
+    previouslyFocused?.focus?.();
+    previouslyFocused = null;
+  }
 });
+
+/** Focus trap + Escape to close (a11y for the mobile drawer). */
+const onDrawerKeydown = (e: KeyboardEvent) => {
+  if (e.key === 'Escape') {
+    mobileOpen.value = false;
+    return;
+  }
+  if (e.key !== 'Tab' || !drawerEl.value) return;
+  const focusables = drawerEl.value.querySelectorAll<HTMLElement>(
+    'a[href], button, [tabindex]:not([tabindex="-1"])',
+  );
+  if (!focusables.length) return;
+  const first = focusables[0];
+  const last = focusables[focusables.length - 1];
+  if (e.shiftKey && document.activeElement === first) {
+    e.preventDefault();
+    last.focus();
+  } else if (!e.shiftKey && document.activeElement === last) {
+    e.preventDefault();
+    first.focus();
+  }
+};
 
 onMounted(() => {
   mounted.value = true;
@@ -199,7 +232,15 @@ const isOverlay = computed(() => !!props.overlay && !scrolled.value);
 
   <Teleport v-if="mounted" to="body">
     <Transition name="fade">
-      <div v-if="mobileOpen" class="fixed inset-0 z-50 flex flex-col bg-background md:hidden">
+      <div
+        v-if="mobileOpen"
+        ref="drawerEl"
+        class="fixed inset-0 z-50 flex flex-col bg-background md:hidden"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Menu"
+        @keydown="onDrawerKeydown"
+      >
         <div class="flex h-16 items-center justify-between border-b border-line px-6">
           <span class="mono-label">Menu</span>
           <button

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -123,10 +123,11 @@ const softwareDocs = defineCollection({
       if (parts[1] === 'README.adoc') return `${product}/README`;
       return `${product}/${parts.slice(1).join('/').replace(/^docs\//, '').replace(/\.adoc$/, '')}`;
     },
-    dataFromEntry: ({ id, frontMatter, docTitle }) => ({
+    dataFromEntry: ({ id, frontMatter, docTitle, toc }) => ({
       ...frontMatter,
       title: frontMatter.title ?? docTitle ?? id.split('/').pop() ?? id,
       product: id.split('/')[0],
+      toc: toc ?? [],
     }),
     transformHtml: (html, { id }) => {
       const product = id.split('/')[0];
@@ -143,6 +144,9 @@ const softwareDocs = defineCollection({
   schema: z.object({
     title: z.string(),
     product: z.string(),
+    toc: z
+      .array(z.object({ id: z.string(), title: z.string(), level: z.number() }))
+      .default([]),
   }),
 });
 
@@ -163,7 +167,7 @@ const manpages = defineCollection({
       const file = rel.split('/').pop()!.replace(/\.adoc$/, ''); // rnp.1 | rnpkeys.1 | librnp.3
       return file.replace(/\./g, '-'); // rnp-1 | rnpkeys-1 | librnp-3
     },
-    dataFromEntry: ({ id, body, docTitle }) => {
+    dataFromEntry: ({ id, body, docTitle, toc }) => {
       const nameSection = body.match(/==\s*NAME\s*\r?\n\r?\n([^\n]+)/);
       const desc = nameSection?.[1]?.split(' - ')[1]?.replace(/[.\s]+$/, '') ?? '';
       return {
@@ -171,6 +175,7 @@ const manpages = defineCollection({
         description: desc,
         section: id.endsWith('-3') ? 3 : 1,
         version: RNP_VERSION,
+        toc: toc ?? [],
       };
     },
   }),
@@ -179,6 +184,9 @@ const manpages = defineCollection({
     description: z.string().default(''),
     section: z.number(),
     version: z.string(),
+    toc: z
+      .array(z.object({ id: z.string(), title: z.string(), level: z.number() }))
+      .default([]),
   }),
 });
 

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -113,12 +113,52 @@ const jsonLd = {
     <ClientRouter />
   </head>
   <body class="flex min-h-screen flex-col bg-background text-foreground">
+    <a href="#main" class="skip-link btn btn-primary">Skip to content</a>
     <SiteHeader client:load currentPath={Astro.url.pathname} overlay={headerOverlay} />
-    <main class="w-full flex-1" data-pagefind-body>
+    <main id="main" class="w-full flex-1" data-pagefind-body>
       <slot />
     </main>
     <SiteFooter />
     <SiteSearch client:only="vue" />
     <EasterEggs client:load />
+    <script>
+      // Progressive enhancement: copy button on every code block.
+      const enhanceCopy = () => {
+        document
+          .querySelectorAll('.prose pre:not([data-copyable]), .adoc-content pre:not([data-copyable])')
+          .forEach((pre) => {
+            pre.setAttribute('data-copyable', '');
+            const btn = document.createElement('button');
+            btn.type = 'button';
+            btn.className = 'copy-btn';
+            btn.textContent = 'Copy';
+            btn.setAttribute('aria-label', 'Copy code to clipboard');
+            btn.addEventListener('click', async () => {
+              const code = pre.querySelector('code')?.textContent ?? pre.textContent ?? '';
+              try {
+                await navigator.clipboard.writeText(code);
+              } catch {
+                const ta = document.createElement('textarea');
+                ta.value = code;
+                ta.style.position = 'fixed';
+                ta.style.opacity = '0';
+                document.body.appendChild(ta);
+                ta.select();
+                document.execCommand('copy');
+                ta.remove();
+              }
+              btn.textContent = 'Copied';
+              btn.classList.add('copied');
+              setTimeout(() => {
+                btn.textContent = 'Copy';
+                btn.classList.remove('copied');
+              }, 1500);
+            });
+            pre.appendChild(btn);
+          });
+      };
+      enhanceCopy();
+      document.addEventListener('astro:after-swap', enhanceCopy);
+    </script>
   </body>
 </html>

--- a/src/layouts/DocsLayout.astro
+++ b/src/layouts/DocsLayout.astro
@@ -1,6 +1,7 @@
 ---
 import BaseLayout from '@/layouts/BaseLayout.astro';
 import Prose from '@/components/Prose.astro';
+import TocNav from '@/components/TocNav.astro';
 
 interface Props {
   title: string;
@@ -9,12 +10,35 @@ interface Props {
   productTitle: string;
   docs: { slug: string; title: string }[];
   currentSlug: string;
+  toc?: { id: string; title: string; level: number }[];
 }
 
-const { title, description, product, productTitle, docs, currentSlug } = Astro.props;
+const { title, description, product, productTitle, docs, currentSlug, toc = [] } = Astro.props;
+
+const breadcrumbLd = {
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: 'Software', item: `https://www.rnpgp.org/software/` },
+    {
+      '@type': 'ListItem',
+      position: 2,
+      name: productTitle,
+      item: `https://www.rnpgp.org/software/${product}/`,
+    },
+    {
+      '@type': 'ListItem',
+      position: 3,
+      name: 'Documentation',
+      item: `https://www.rnpgp.org/software/${product}/docs/`,
+    },
+    { '@type': 'ListItem', position: 4, name: title },
+  ],
+};
 ---
 
 <BaseLayout title={title} description={description}>
+  <script type="application/ld+json" set:html={JSON.stringify(breadcrumbLd)} />
   <header class="border-b border-line bg-surface-dim">
     <div class="mx-auto w-full max-w-6xl px-6 pb-8 pt-24">
       <nav class="font-mono text-xs text-faint">
@@ -33,7 +57,7 @@ const { title, description, product, productTitle, docs, currentSlug } = Astro.p
   </header>
 
   <section class="mx-auto w-full max-w-6xl px-6 py-10">
-    <div class="grid gap-10 lg:grid-cols-[15rem_1fr]">
+    <div class="grid gap-10 lg:grid-cols-[15rem_minmax(0,1fr)] xl:grid-cols-[15rem_minmax(0,1fr)_10.5rem]">
       <aside>
         <div class="lg:sticky lg:top-24">
           <p class="mono-label">Documentation</p>
@@ -62,6 +86,7 @@ const { title, description, product, productTitle, docs, currentSlug } = Astro.p
           <slot />
         </Prose>
       </div>
+      <TocNav toc={toc} />
     </div>
   </section>
 </BaseLayout>

--- a/src/lib/asciidoc.ts
+++ b/src/lib/asciidoc.ts
@@ -23,6 +23,33 @@ export function splitFrontMatter(raw: string): SplitAdoc {
   return { frontMatter, body: raw.slice(m[0].length) };
 }
 
+function decodeEntities(s: string): string {
+  return s
+    .replace(/<[^>]+>/g, '')
+    .replace(/&#x([0-9a-fA-F]+);/g, (_, h) => String.fromCodePoint(parseInt(h, 16)))
+    .replace(/&#(\d+);/g, (_, n) => String.fromCodePoint(Number(n)))
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .trim();
+}
+
+export interface TocItem {
+  id: string;
+  title: string;
+  level: number;
+}
+
+/** Extract h2/h3 headings (id + text) from rendered HTML for on-page TOCs. */
+export function extractToc(html: string): TocItem[] {
+  const out: TocItem[] = [];
+  for (const m of html.matchAll(/<h([23])[^>]*id="([^"]+)"[^>]*>([\s\S]*?)<\/h\1>/g)) {
+    out.push({ id: m[2], title: decodeEntities(m[3]), level: Number(m[1]) });
+  }
+  return out;
+}
+
 /** Render an AsciiDoc string to an HTML fragment (embedded mode, no page chrome). */
 export async function renderAdoc(body: string, attributes: Record<string, string> = {}) {
   const doc = await loadAdoc(body, {
@@ -75,6 +102,7 @@ export interface AdocLoaderOptions {
     frontMatter: Record<string, any>;
     body: string;
     docTitle?: string;
+    toc?: TocItem[];
   }) => Record<string, any>;
   /** Post-process rendered HTML per entry (e.g. link rewriting). */
   transformHtml?: (html: string, ctx: { id: string; rel: string }) => string;
@@ -114,7 +142,7 @@ export function adocLoader(options: AdocLoaderOptions): Loader {
         const id = options.idFromRel ? options.idFromRel(rel) : rel.replace(/\.adoc$/, '');
         if (options.transformHtml) html = options.transformHtml(html, { id, rel });
         const extra = options.dataFromEntry
-          ? options.dataFromEntry({ id, rel, frontMatter, body, docTitle })
+          ? options.dataFromEntry({ id, rel, frontMatter, body, docTitle, toc: extractToc(html) })
           : {};
         const data = await parseData({
           id,

--- a/src/pages/blog/[...id].astro
+++ b/src/pages/blog/[...id].astro
@@ -25,6 +25,37 @@ const { post, redirectTo } = Astro.props;
 
 const Content = post ? (await render(post)).Content : undefined;
 const dateISO = post ? post.data.date.toISOString().slice(0, 10) : '';
+
+let newer: CollectionEntry<'blog'> | null = null;
+let older: CollectionEntry<'blog'> | null = null;
+let blogPostingLd: object | null = null;
+if (post) {
+  const posts = (await getCollection('blog')).sort(
+    (a, b) => b.data.date.valueOf() - a.data.date.valueOf(),
+  );
+  const idx = posts.findIndex((p) => p.id === post.id);
+  newer = idx > 0 ? posts[idx - 1] : null;
+  older = idx >= 0 && idx < posts.length - 1 ? posts[idx + 1] : null;
+  blogPostingLd = {
+    '@context': 'https://schema.org',
+    '@type': 'BlogPosting',
+    headline: post.data.title,
+    description: post.data.excerpt ?? post.data.title,
+    datePublished: post.data.date.toISOString(),
+    author: post.data.authors.map((a) => ({
+      '@type': 'Person',
+      name: a.name,
+      ...(a.email ? { email: a.email } : {}),
+    })),
+    publisher: {
+      '@type': 'Organization',
+      name: 'RNP',
+      url: 'https://www.rnpgp.org',
+      logo: { '@type': 'ImageObject', url: 'https://www.rnpgp.org/favicon-192x192.png' },
+    },
+    mainEntityOfPage: `https://www.rnpgp.org/blog/${post.id}/`,
+  };
+}
 ---
 
 {
@@ -72,6 +103,7 @@ const dateISO = post ? post.data.date.toISOString().slice(0, 10) : '';
         type="article"
         publishedTime={post.data.date.toISOString()}
       >
+        {blogPostingLd && <script type="application/ld+json" set:html={JSON.stringify(blogPostingLd)} />}
         <article class="mx-auto w-full max-w-3xl px-6 pb-20 pt-28">
           <header>
             <div class="flex flex-wrap items-center gap-x-4 gap-y-2">
@@ -118,7 +150,29 @@ const dateISO = post ? post.data.date.toISOString().slice(0, 10) : '';
             <hr class="gradient-rule mt-8" />
           </header>
           <Prose class="mt-10">{Content && <Content />}</Prose>
-          <div class="mt-16 border-t border-line pt-6">
+          <nav class="mt-16 grid gap-4 border-t border-line pt-8 sm:grid-cols-2" aria-label="More posts">
+            {
+              older ? (
+                <a href={`/blog/${older.id}/`} class="card card-hover block p-4">
+                  <span class="mono-label">← Older</span>
+                  <span class="mt-1 block font-sans font-bold leading-snug">{older.data.title}</span>
+                </a>
+              ) : (
+                <span aria-hidden="true" />
+              )
+            }
+            {
+              newer ? (
+                <a href={`/blog/${newer.id}/`} class="card card-hover block p-4 sm:text-right">
+                  <span class="mono-label">Newer →</span>
+                  <span class="mt-1 block font-sans font-bold leading-snug">{newer.data.title}</span>
+                </a>
+              ) : (
+                <span aria-hidden="true" />
+              )
+            }
+          </nav>
+          <div class="mt-8">
             <a href="/blog/" class="font-sans text-sm font-bold text-accent">
               ← All posts
             </a>

--- a/src/pages/docs/[id].astro
+++ b/src/pages/docs/[id].astro
@@ -3,6 +3,7 @@ import { getCollection, render } from 'astro:content';
 import BaseLayout from '@/layouts/BaseLayout.astro';
 import PageHero from '@/components/PageHero.astro';
 import Prose from '@/components/Prose.astro';
+import TocNav from '@/components/TocNav.astro';
 
 export async function getStaticPaths() {
   const manpages = await getCollection('manpages');
@@ -21,12 +22,17 @@ const { Content } = await render(entry);
     description={data.description}
   />
 
-  <article class="mx-auto w-full max-w-3xl px-6 py-14">
-    <Prose>
-      <Content />
-    </Prose>
-    <p class="mono-label mt-14 border-t border-line pt-6">
-      Rendered from the RNP v{data.version} release · Source: github.com/rnpgp/rnp
-    </p>
-  </article>
+  <div class="mx-auto w-full max-w-6xl px-6 py-14">
+    <div class="grid gap-10 xl:grid-cols-[minmax(0,1fr)_10.5rem]">
+      <article class="w-full min-w-0 max-w-3xl">
+        <Prose>
+          <Content />
+        </Prose>
+        <p class="mono-label mt-14 border-t border-line pt-6">
+          Rendered from the RNP v{data.version} release · Source: github.com/rnpgp/rnp
+        </p>
+      </article>
+      <TocNav toc={data.toc} />
+    </div>
+  </div>
 </BaseLayout>

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -1,20 +1,39 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import rss from '@astrojs/rss';
-import { getCollection } from 'astro:content';
 import type { APIContext } from 'astro';
+import { getCollection } from 'astro:content';
+import { renderAdoc, splitFrontMatter } from '@/lib/asciidoc';
 
 export async function GET(context: APIContext) {
   const posts = (await getCollection('blog')).sort(
     (a, b) => b.data.date.valueOf() - a.data.date.valueOf(),
   );
-  return rss({
-    title: 'RNP Blog',
-    description: 'Releases, news and updates on the RNP project.',
-    site: context.site!,
-    items: posts.map((p) => ({
+
+  const dir = join(process.cwd(), 'src/content/blog');
+  const files = new Set(readdirSync(dir));
+  const fullContent = async (id: string) => {
+    const file = `${id}.adoc`;
+    if (!files.has(file)) return undefined;
+    const { body } = splitFrontMatter(readFileSync(join(dir, file), 'utf8'));
+    const { html } = await renderAdoc(body);
+    return html;
+  };
+
+  const items = await Promise.all(
+    posts.map(async (p) => ({
       title: p.data.title,
       pubDate: p.data.date,
       description: p.data.excerpt ?? p.data.title,
       link: `/blog/${p.id}/`,
+      content: await fullContent(p.id),
     })),
+  );
+
+  return rss({
+    title: 'RNP Blog',
+    description: 'Releases, news and updates on the RNP project.',
+    site: context.site!,
+    items,
   });
 }

--- a/src/pages/software/[product]/docs/[...slug].astro
+++ b/src/pages/software/[product]/docs/[...slug].astro
@@ -51,6 +51,7 @@ const { Content } = await render(entry);
   productTitle={productTitle}
   docs={docs}
   currentSlug={docPath}
+  toc={entry.data.toc}
 >
   <Content />
 </DocsLayout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -96,7 +96,7 @@
   --surface-dim: #eef4fa;
   --fg: #23273a;
   --fg-soft: #4f5469;
-  --fg-faint: #7e85a1;
+  --fg-faint: #5f6680; /* ≥4.5:1 on paper (AA for small text) */
   --line: #dfe8f2;
   --accent: #1a7bec;
   --accent-deep: #0f5fc4;
@@ -433,6 +433,58 @@
     font-family: var(--font-mono);
     letter-spacing: 0.08em;
     word-spacing: 0.4em;
+  }
+
+  /* Copy button injected into every code block (scripts in BaseLayout) */
+  pre[data-copyable] {
+    position: relative;
+  }
+  .copy-btn {
+    position: absolute;
+    top: 0.55rem;
+    right: 0.55rem;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    border: 1px solid rgb(255 255 255 / 0.16);
+    border-radius: 0.4rem;
+    background: rgb(255 255 255 / 0.06);
+    color: rgb(232 234 242 / 0.65);
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    padding: 0.2rem 0.55rem;
+    cursor: pointer;
+    transition:
+      color 0.15s,
+      border-color 0.15s,
+      opacity 0.15s;
+    opacity: 0;
+  }
+  pre[data-copyable]:hover .copy-btn,
+  .copy-btn:focus-visible {
+    opacity: 1;
+  }
+  .copy-btn:hover {
+    color: #fff;
+    border-color: rgb(255 255 255 / 0.45);
+  }
+  .copy-btn.copied {
+    color: var(--color-teal);
+    border-color: var(--color-teal);
+    opacity: 1;
+  }
+
+  /* Skip to content (visually hidden until focused) */
+  .skip-link {
+    position: fixed;
+    top: 0.75rem;
+    left: 0.75rem;
+    z-index: 100;
+    transform: translateY(-300%);
+    transition: transform 0.18s ease-out;
+  }
+  .skip-link:focus-visible {
+    transform: none;
   }
 
   /* Scroll reveal */


### PR DESCRIPTION
## The two selected bundles, complete

**UX + accessibility**

- **Copy buttons on every code block** — progressive enhancement over `.prose` / `.adoc-content` pre blocks, hover/focus reveal, clipboard API + fallback, re-applies after ClientRouter navigations
- **Sticky "On this page" TOC** on man pages and software docs — h2s extracted in the adoc loader (`rnp(1)` now shows NAME → SEE ALSO), only rendered when ≥4 sections, xl screens
- **Skip-to-content link**, **focus trap + Escape + focus-restore** in the mobile drawer, faint-text contrast bumped to ≥4.5:1 (AA small text)
- **Prev/next post navigation**

**SEO + feeds**

- `BlogPosting` JSON-LD on posts (authors, publisher, dates), `BreadcrumbList` JSON-LD on docs
- **RSS now full-content** (adoc sources rendered at build into `content:encoded`), no more excerpt-only

All verified: build green, internal links clean, e2e **29/29**, TOC/copy-button confirmed visually and in DOM.
