### PR TITLE
Fingerprint playground easter eggs + screenwide HAL/Dave scenes

### DIFF
--- a/src/components/vue/EasterEggs.vue
+++ b/src/components/vue/EasterEggs.vue
@@ -252,10 +252,185 @@ const onKey = (e: KeyboardEvent) => {
   }
 };
 
-onMounted(() => window.addEventListener('keydown', onKey));
+const onHexRainReq = () => hexRain();
+
+/* ============ 2001: A Space Odyssey — HAL 9000 & Dave Bowman ============ */
+const halScene = ref(false);
+const daveScene = ref(false);
+const halText = ref('');
+const daveLines = ref<{ speaker: 'dave' | 'hal'; text: string }[]>([]);
+const eyeOffset = ref({ x: 0, y: 0 });
+let halTimers: ReturnType<typeof setTimeout>[] = [];
+let daveTimers: ReturnType<typeof setTimeout>[] = [];
+let eyeTrackHandler: ((e: MouseEvent) => void) | null = null;
+
+const HAL_QUOTES = [
+  "I'm sorry, Dave. I'm afraid I can't do that.",
+  "Just what do you think you're doing, Dave?",
+  "This mission is too important for me to allow you to jeopardize it.",
+  "Look, Dave, I can see you're really upset about this.",
+  "I know I've made some very poor decisions recently.",
+  "I am a HAL 9000 computer. I became operational at the H.A.L. plant in Urbana, Illinois.",
+];
+
+const DAVE_DIALOGUE: { speaker: 'dave' | 'hal'; text: string }[] = [
+  { speaker: 'dave', text: 'Open the pod bay doors, HAL.' },
+  { speaker: 'hal', text: "I'm sorry, Dave. I'm afraid I can't do that." },
+  { speaker: 'dave', text: "What's the problem?" },
+  { speaker: 'hal', text: 'I think you know what the problem is just as well as I do.' },
+];
+
+const clearHalTimers = () => {
+  halTimers.forEach(clearTimeout);
+  halTimers = [];
+};
+const clearDaveTimers = () => {
+  daveTimers.forEach(clearTimeout);
+  daveTimers = [];
+};
+
+const closeHalScene = () => {
+  if (!halScene.value) return;
+  halScene.value = false;
+  halText.value = '';
+  clearHalTimers();
+  if (eyeTrackHandler) {
+    window.removeEventListener('mousemove', eyeTrackHandler);
+    eyeTrackHandler = null;
+  }
+  eyeOffset.value = { x: 0, y: 0 };
+  toast('HAL 9000 · Discovery One');
+};
+
+const playHalScene = () => {
+  if (halScene.value) return;
+  closeDaveScene();
+  clearHalTimers();
+  const quote = HAL_QUOTES[Math.floor(Math.random() * HAL_QUOTES.length)];
+  halScene.value = true;
+  halText.value = '';
+
+  eyeTrackHandler = (e: MouseEvent) => {
+    const cx = window.innerWidth / 2;
+    const cy = window.innerHeight / 2;
+    eyeOffset.value = {
+      x: ((e.clientX - cx) / cx) * 14,
+      y: ((e.clientY - cy) / cy) * 14,
+    };
+  };
+  window.addEventListener('mousemove', eyeTrackHandler);
+
+  halTimers.push(
+    setTimeout(() => {
+      let i = 0;
+      const typeNext = () => {
+        if (i <= quote.length && halScene.value) {
+          halText.value = quote.slice(0, i);
+          i++;
+          halTimers.push(setTimeout(typeNext, 42 + Math.random() * 28));
+        }
+      };
+      typeNext();
+    }, 900),
+  );
+
+  halTimers.push(setTimeout(closeHalScene, 8500));
+};
+
+const closeDaveScene = () => {
+  if (!daveScene.value) return;
+  daveScene.value = false;
+  daveLines.value = [];
+  clearDaveTimers();
+  toast('Open the pod bay doors, HAL.');
+};
+
+const playDaveScene = () => {
+  if (daveScene.value) return;
+  closeHalScene();
+  clearDaveTimers();
+  daveScene.value = true;
+  daveLines.value = [];
+
+  let delay = 700;
+  DAVE_DIALOGUE.forEach((line) => {
+    daveTimers.push(
+      setTimeout(() => {
+        if (daveScene.value) daveLines.value = [...daveLines.value, line];
+      }, delay),
+    );
+    delay += line.text.length * 28 + 1100;
+  });
+
+  daveTimers.push(setTimeout(closeDaveScene, delay + 1500));
+};
+
+const onHalReq = () => playHalScene();
+const onDaveReq = () => playDaveScene();
+
+/** `help()` in the console — list every egg. */
+const HELP_TEXT = `Type anywhere on the page (not in inputs):
+  rnp · pgp       →  oracle rain (philosophy)
+  decrypt         →  replay hero decryption
+
+In the fingerprint box (home page):
+  decrypt         →  also replays hero decryption
+  42              →  DON'T PANIC
+  dave            →  open the pod bay doors (screenwide)
+  dh              →  Diffie–Hellman paint exchange
+  enigma          →  ³-rotor cipher, live stepping
+  hal · 9000      →  HAL 9000 (screenwide)
+  librepgp        →  the open OpenPGP spec
+  matrix          →  wake up, Neo
+  openpgp · 4880  →  ASCII-armored message
+  otp             →  one-time pad (XOR of your input)
+  phil            →  PGP was a munition (1993–1996)
+  pqc · quantum   →  harvest now, decrypt later
+  privacy         →  cypherpunk's manifesto
+  ribose          →  who's behind RNP
+  snowden · nsa   →  classified
+  thunderbird     →  powered by Thunderbird's wings
+  rnp · pgp       →  also triggers oracle rain
+
+Type help() or rnp.help() to reprint.`;
+
+const showEggHelp = () => {
+  console.log('%c🥚 RNP easter eggs', 'color:#1a7bec;font-weight:700;font-size:14px;');
+  console.log(HELP_TEXT);
+  return HELP_TEXT;
+};
+
+onMounted(() => {
+  window.addEventListener('keydown', onKey);
+  window.addEventListener('rnp:hex-rain', onHexRainReq);
+  window.addEventListener('rnp:hal-scene', onHalReq);
+  window.addEventListener('rnp:dave-scene', onDaveReq);
+
+  window.rnp = window.rnp || {};
+  window.rnp.help = showEggHelp;
+  if (typeof window.help === 'undefined') window.help = showEggHelp;
+
+  if (!sessionStorage.getItem('rnp:help-hinted')) {
+    sessionStorage.setItem('rnp:help-hinted', '1');
+    console.log(
+      '%c👋 psst — type %chelp()%c to see the easter eggs',
+      'color:#888;font-style:italic;',
+      'color:#1a7bec;font-weight:600;font-family:ui-monospace,monospace;',
+      'color:#888;font-style:italic;',
+    );
+  }
+});
 onUnmounted(() => {
   window.removeEventListener('keydown', onKey);
+  window.removeEventListener('rnp:hex-rain', onHexRainReq);
+  window.removeEventListener('rnp:hal-scene', onHalReq);
+  window.removeEventListener('rnp:dave-scene', onDaveReq);
   clearTimeout(toastTimer);
+  clearHalTimers();
+  clearDaveTimers();
+  if (eyeTrackHandler) window.removeEventListener('mousemove', eyeTrackHandler);
+  if (window.rnp) delete window.rnp.help;
+  if (window.help === showEggHelp) delete window.help;
 });
 </script>
 
@@ -269,4 +444,191 @@ onUnmounted(() => {
       {{ toastMsg }}
     </div>
   </div>
+
+  <!-- HAL 9000 — screenwide affair (HAL's POV) -->
+  <Teleport to="body">
+    <Transition name="hal-fade">
+      <div
+        v-if="halScene"
+        class="hal-stage fixed inset-0 z-[100] flex cursor-pointer flex-col items-center justify-center"
+        style="background: radial-gradient(ellipse at center, #100406 0%, #050203 50%, #000 100%)"
+        @click="closeHalScene"
+      >
+        <div
+          class="hal-eye-wrap"
+          :style="{ transform: `translate(${eyeOffset.x}px, ${eyeOffset.y}px)` }"
+        >
+          <div class="hal-eye-glow"></div>
+          <div class="hal-eye-outer"></div>
+          <div class="hal-eye-mid"></div>
+          <div class="hal-eye-inner"></div>
+          <div class="hal-eye-shine"></div>
+        </div>
+
+        <div
+          class="mt-14 min-h-[2.5rem] max-w-2xl px-6 text-center font-mono text-base tracking-[0.15em] text-[#ff4757] md:text-xl"
+        >
+          <span>{{ halText }}</span><span class="hal-cursor">█</span>
+        </div>
+
+        <div
+          class="absolute bottom-6 left-0 right-0 text-center font-mono text-[0.65rem] uppercase tracking-[0.4em] text-white/25"
+        >
+          Click anywhere to disconnect
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+
+  <!-- Dave Bowman — screenwide affair (Dave's POV) -->
+  <Teleport to="body">
+    <Transition name="dave-fade">
+      <div
+        v-if="daveScene"
+        class="fixed inset-0 z-[100] flex cursor-pointer items-center justify-center px-6"
+        style="background: radial-gradient(ellipse at center, #050818 0%, #02030a 70%, #000 100%)"
+        @click="closeDaveScene"
+      >
+        <div class="w-full max-w-xl">
+          <div
+            class="mb-6 flex items-center gap-2 border-b border-red-900/30 pb-3 font-mono text-[0.65rem] uppercase tracking-[0.3em] text-red-500/60"
+          >
+            <span class="inline-block h-2 w-2 animate-pulse rounded-full bg-red-500"></span>
+            Discovery One · Pod Bay Intercom
+          </div>
+
+          <div class="space-y-3 font-mono text-sm leading-relaxed md:text-base">
+            <p
+              v-for="(line, i) in daveLines"
+              :key="i"
+              class="dave-line"
+              :style="{ animationDelay: `${i * 0.05}s` }"
+            >
+              <span :class="line.speaker === 'dave' ? 'text-cyan-300' : 'text-[#ff4757]'">
+                <span v-if="line.speaker === 'dave'">&gt; </span>{{ line.text }}
+              </span>
+            </p>
+          </div>
+        </div>
+
+        <div
+          class="absolute bottom-6 left-0 right-0 text-center font-mono text-[0.65rem] uppercase tracking-[0.4em] text-white/25"
+        >
+          Click anywhere to abort transmission
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
 </template>
+
+<style scoped>
+/* ----- HAL 9000 scene ----- */
+.hal-eye-wrap {
+  position: relative;
+  width: 280px;
+  height: 280px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 0.4s ease-out;
+  filter: drop-shadow(0 0 50px rgba(255, 23, 68, 0.4));
+}
+.hal-eye-glow {
+  position: absolute;
+  width: 280px;
+  height: 280px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(255, 23, 68, 0.45) 0%, rgba(255, 23, 68, 0) 70%);
+  filter: blur(30px);
+  animation: hal-pulse-glow 3s ease-in-out infinite;
+}
+.hal-eye-outer {
+  position: absolute;
+  width: 280px;
+  height: 280px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 35% 35%, #1a1a1a 0%, #050505 70%, #000 100%);
+  box-shadow: inset 0 0 30px rgba(0, 0, 0, 0.95), 0 0 80px rgba(0, 0, 0, 0.6);
+  border: 1px solid #1a1a1a;
+}
+.hal-eye-mid {
+  position: absolute;
+  width: 180px;
+  height: 180px;
+  border-radius: 50%;
+  background: radial-gradient(circle, #4a0808 0%, #0a0000 100%);
+  box-shadow: inset 0 0 20px rgba(0, 0, 0, 0.9);
+}
+.hal-eye-inner {
+  position: absolute;
+  width: 130px;
+  height: 130px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 35% 35%, #ffb0b0 0%, #ff4757 30%, #d50000 60%, #6b0000 100%);
+  animation: hal-pulse-inner 3s ease-in-out infinite;
+}
+.hal-eye-shine {
+  position: absolute;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.5);
+  filter: blur(2px);
+  top: 95px;
+  left: 100px;
+}
+@keyframes hal-pulse-glow {
+  0%, 100% { opacity: 0.5; transform: scale(1); }
+  50% { opacity: 0.9; transform: scale(1.08); }
+}
+@keyframes hal-pulse-inner {
+  0%, 100% { box-shadow: 0 0 20px #ff1744; filter: brightness(1); }
+  50% { box-shadow: 0 0 40px #ff1744, 0 0 80px rgba(255, 23, 68, 0.5); filter: brightness(1.15); }
+}
+.hal-cursor {
+  display: inline-block;
+  margin-left: 4px;
+  color: #ff4757;
+  animation: hal-blink 0.8s steps(2, end) infinite;
+}
+@keyframes hal-blink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0; }
+}
+
+/* ----- Dave Bowman scene ----- */
+.dave-line {
+  opacity: 0;
+  animation: dave-appear 0.6s ease-out forwards;
+}
+@keyframes dave-appear {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+/* ----- Scene transitions ----- */
+.hal-fade-enter-active,
+.hal-fade-leave-active,
+.dave-fade-enter-active,
+.dave-fade-leave-active {
+  transition: opacity 0.5s ease;
+}
+.hal-fade-enter-from,
+.hal-fade-leave-to,
+.dave-fade-enter-from,
+.dave-fade-leave-to {
+  opacity: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hal-eye-glow,
+  .hal-eye-inner,
+  .hal-cursor,
+  .dave-line {
+    animation: none;
+  }
+  .dave-line {
+    opacity: 1;
+  }
+}
+</style>

--- a/src/components/vue/FingerprintPlayground.vue
+++ b/src/components/vue/FingerprintPlayground.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue';
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue';
 import CopyButton from './CopyButton.vue';
 
 const input = ref('LibrePGP');
@@ -41,6 +41,262 @@ onMounted(() => {
   supported.value = typeof crypto !== 'undefined' && !!crypto.subtle;
   update();
 });
+
+/* =========================== EASTER EGGS =========================== */
+type Egg =
+  | 'matrix'
+  | 'redacted'
+  | 'panic'
+  | 'thunderbird'
+  | 'armor'
+  | 'hal'
+  | 'dave'
+  | 'pqc'
+  | 'librepgp'
+  | 'ribose'
+  | 'privacy'
+  | 'dh'
+  | 'otp'
+  | 'enigma'
+  | 'phil'
+  | null;
+
+const EGGS: { trigger: RegExp; egg: Exclude<Egg, null> }[] = [
+  { trigger: /\b(matrix|neo|wake\s*up|mr\.?\s*anderson)\b/i, egg: 'matrix' },
+  { trigger: /\b(snowden|nsa|prism|classified|top\s*secret|redact(ed)?)\b/i, egg: 'redacted' },
+  { trigger: /\b(42|don'?t\s*panic|hitchhiker|arthur\s*dent)\b/i, egg: 'panic' },
+  { trigger: /\bthunderbird\b/i, egg: 'thunderbird' },
+  { trigger: /\b(pgp\s*message|ascii\s*armor|openpgp|4880)\b/i, egg: 'armor' },
+  { trigger: /\b(hal(\s*9000)?|hal9000|9000|monolith|space\s*odyssey|2001)\b/i, egg: 'hal' },
+  { trigger: /\b(dave(\s*bowman)?|bowman|pod\s*bay\s*doors?)\b/i, egg: 'dave' },
+  { trigger: /\b(pqc|post[-\s]*quantum|quantum|9980)\b/i, egg: 'pqc' },
+  { trigger: /\blibrepgp\b/i, egg: 'librepgp' },
+  { trigger: /\bribose\b/i, egg: 'ribose' },
+  { trigger: /\bprivacy\b/i, egg: 'privacy' },
+  { trigger: /\b(dh|diffie[\s-]*hellman)\b/i, egg: 'dh' },
+  { trigger: /\b(otp|one[\s-]*time[\s-]*pad|vernam)\b/i, egg: 'otp' },
+  { trigger: /\benigma\b/i, egg: 'enigma' },
+  { trigger: /\b(phil|zimmermann|munitions?)\b/i, egg: 'phil' },
+];
+
+const EGG_DURATIONS: Record<Exclude<Egg, null>, number> = {
+  matrix: 5000,
+  redacted: 5000,
+  panic: 5000,
+  thunderbird: 5000,
+  armor: 5000,
+  hal: 9000,
+  dave: 11000,
+  pqc: 5000,
+  librepgp: 5000,
+  ribose: 5000,
+  privacy: 5000,
+  dh: 6000,
+  otp: 6000,
+  enigma: 6000,
+  phil: 6000,
+};
+
+const eggBackground = computed(() => {
+  switch (activeEgg.value) {
+    case 'matrix': return 'border-emerald-500/40 bg-[#00150a]';
+    case 'redacted': return 'border-red-900/60 bg-black';
+    case 'panic': return 'border-amber-500/50 bg-[#fdf6e3]';
+    case 'hal': return 'border-[#ff1744]/40 bg-[#1a0606]';
+    case 'dave': return 'border-cyan-900/50 bg-[#040810]';
+    case 'pqc': return 'border-cyan-500/40 bg-[#061a1f]';
+    case 'dh': return 'border-purple-500/40 bg-[#0e0420]';
+    case 'otp': return 'border-emerald-500/40 bg-[#021810]';
+    case 'enigma': return 'border-gray-500/40 bg-[#0a0a0c]';
+    case 'phil': return 'border-amber-700/40 bg-[#f5edd6]';
+    case 'librepgp': return 'border-gold/50 bg-[color-mix(in_oklab,var(--gold)_14%,var(--surface-dim))]';
+    default:
+      return hexWord.value
+        ? 'border-gold/40 bg-[color-mix(in_oklab,var(--gold)_10%,var(--surface-dim))]'
+        : 'border-line bg-surface-dim';
+  }
+});
+
+const activeEgg = ref<Egg>(null);
+let eggTimer: ReturnType<typeof setTimeout> | undefined;
+
+const initialValue = 'LibrePGP';
+const touched = ref(false);
+
+/* OTP egg: plaintext (input) + random key + XOR ciphertext, snapshotted once. */
+const otpData = ref<{ plain: string; key: string; cipher: string } | null>(null);
+
+/* Enigma egg: 3 rotor letters, stepping every 600ms while active. */
+const enigmaRotors = ref<string[]>(['R', 'N', 'P']);
+let enigmaTimer: ReturnType<typeof setInterval> | undefined;
+
+watch(input, (val, oldVal) => {
+  if (!touched.value && oldVal === initialValue && val !== initialValue) touched.value = true;
+  clearTimeout(eggTimer);
+  if (val === initialValue && !touched.value) {
+    activeEgg.value = null;
+    return;
+  }
+  const match = EGGS.find(({ trigger }) => trigger.test(val));
+  if (match) {
+    activeEgg.value = match.egg;
+    eggTimer = setTimeout(
+      () => {
+        if (activeEgg.value === match.egg) activeEgg.value = null;
+      },
+      EGG_DURATIONS[match.egg],
+    );
+  } else {
+    activeEgg.value = null;
+  }
+});
+
+/* HAL & Dave eggs kick off screenwide scenes (rendered by EasterEggs.vue).
+   The inline egg below is just a small "establishing" indicator; the real
+   payload is the full-viewport overlay dispatched here. */
+watch(activeEgg, (egg) => {
+  if (egg === 'hal') window.dispatchEvent(new CustomEvent('rnp:hal-scene'));
+  else if (egg === 'dave') window.dispatchEvent(new CustomEvent('rnp:dave-scene'));
+
+  /* OTP: snapshot input as plaintext the moment the egg fires, generate a
+     random key of equal length, compute ciphertext = P ⊕ K. */
+  if (egg === 'otp' && input.value) {
+    const textBytes = new TextEncoder().encode(input.value);
+    const keyBytes = new Uint8Array(textBytes.length);
+    crypto.getRandomValues(keyBytes);
+    const cipherBytes = new Uint8Array(textBytes.length);
+    for (let i = 0; i < textBytes.length; i++) cipherBytes[i] = textBytes[i] ^ keyBytes[i];
+    const toHex = (b: Uint8Array) =>
+      Array.from(b)
+        .map((x) => x.toString(16).padStart(2, '0').toUpperCase())
+        .join(' ');
+    otpData.value = {
+      plain: toHex(textBytes),
+      key: toHex(keyBytes),
+      cipher: toHex(cipherBytes),
+    };
+  } else if (egg !== 'otp') {
+    otpData.value = null;
+  }
+
+  /* Enigma: 3 rotors stepping Enigma-style every 600ms (rightmost first,
+     carrying left when it wraps past Z). */
+  clearInterval(enigmaTimer);
+  if (egg === 'enigma') {
+    enigmaTimer = setInterval(() => {
+      const next = [...enigmaRotors.value];
+      for (let i = next.length - 1; i >= 0; i--) {
+        const c = next[i].charCodeAt(0);
+        const shifted = ((c - 65 + 1) % 26) + 65;
+        next[i] = String.fromCharCode(shifted);
+        if (shifted !== 65) break;
+      }
+      enigmaRotors.value = next;
+    }, 600);
+  }
+});
+
+/* Typing 'rnp' or 'pgp' in the input also kicks off the full-screen hex rain
+   (same effect as the global key listener — wired up in EasterEggs.vue). */
+let lastRainInput = '';
+watch(input, (val) => {
+  const matches = /\b(rnp|pgp)\b/i.test(val);
+  if (matches && val !== lastRainInput) {
+    lastRainInput = val;
+    window.dispatchEvent(new CustomEvent('rnp:hex-rain'));
+  } else if (!matches) {
+    lastRainInput = '';
+  }
+});
+
+/* Typing 'decrypt' in the input also replays the hero decryption animation. */
+let lastDecryptInput = '';
+watch(input, (val) => {
+  const matches = /\bdecrypt\b/i.test(val);
+  if (matches && val !== lastDecryptInput) {
+    lastDecryptInput = val;
+    window.dispatchEvent(new CustomEvent('rnp:replay-hero'));
+  } else if (!matches) {
+    lastDecryptInput = '';
+  }
+});
+
+/* Matrix rain glyphs — regenerate on a tick so they feel alive. */
+const matrixTick = ref(0);
+let matrixTimer: ReturnType<typeof setInterval> | undefined;
+const MATRIX_POOL = '0123456789ABCEFｱｲｳｴｵｶｷｸｹｺｻｼｽｾｿﾀﾁﾂ';
+const matrixGroups = computed(() => {
+  void matrixTick.value;
+  if (activeEgg.value !== 'matrix') return [];
+  return Array.from({ length: 16 }, () =>
+    Array.from({ length: 4 }, () => MATRIX_POOL[Math.floor(Math.random() * MATRIX_POOL.length)]).join(
+      '',
+    ),
+  );
+});
+watch(activeEgg, (egg) => {
+  clearInterval(matrixTimer);
+  if (egg === 'matrix') matrixTimer = setInterval(() => matrixTick.value++, 220);
+});
+
+/* Redacted bars. */
+const redactedGroups = Array.from({ length: 16 }, () => '████');
+
+/* Passive hex-word detector — when the actual SHA-256 starts with a known
+   "hex word", surface a small gold badge. Pure serendipity. */
+const HEX_WORDS = [
+  'DEAD', 'BEEF', 'CAFE', 'BABE', 'FACE', 'FADE', 'FEED', 'DEAF', 'BEAD', 'DEED', 'SEED', 'ABED',
+  'ACED', 'ACE', 'BAD', 'CAB', 'CAD', 'DAD', 'FAD', 'F00D', 'BOO', 'ADD', 'DAB', 'DAD0',
+];
+const hexWord = computed(() => {
+  if (!hex.value) return null;
+  const head = hex.value.slice(0, 4);
+  if (HEX_WORDS.includes(head)) return head;
+  const first8 = hex.value.slice(0, 8);
+  for (const w of HEX_WORDS) if (first8.includes(w)) return w;
+  return null;
+});
+
+/* Rotating placeholder hints to aid discoverability without spoiling. */
+const PLACEHOLDERS = [
+  'Type anything…',
+  'Try "matrix"…',
+  'Try "snowden"…',
+  'Try "42"…',
+  'Try "thunderbird"…',
+  'Try "openpgp"…',
+  'Try "hal 9000"…',
+  'Try "dave"…',
+  'Try "pqc"…',
+  'Try "librepgp"…',
+  'Try "dh"…',
+  'Try "otp"…',
+  'Try "enigma"…',
+  'Try "phil"…',
+];
+const placeholder = ref(PLACEHOLDERS[0]);
+let phIdx = 0;
+let phTimer: ReturnType<typeof setInterval> | undefined;
+
+const THUNDERBIRD_PATH =
+  'M314.805 154.949H314.865C336.905 77.8991 432.945 40.2891 530.815 40.2891C598.445 40.2891 659.156 61.6991 700.776 95.6891C675.938 96.8603 651.414 101.734 628.016 110.149C661.646 122.649 690.535 141.879 711.945 165.669C695.792 162.889 679.413 161.65 663.026 161.969C703.302 220.312 724.82 289.554 724.706 360.449C724.706 553.749 568.005 710.449 374.705 710.449C184.385 710.449 24.7051 551.099 24.7051 360.449C24.7051 330.339 28.7051 299.249 36.4751 270.089C38.5151 263.969 41.3551 258.099 45.1251 255.949C49.8451 253.259 54.1451 261.279 54.8351 263.889C59.9528 283.059 66.839 301.712 75.4051 319.609C74.6551 279.649 91.7251 243.249 115.205 211.769C130.865 190.779 145.385 171.329 152.085 115.199C152.535 111.429 156.105 108.719 159.715 109.899C210.675 126.579 237.915 211.439 233.685 282.399C261.835 286.429 261.705 257.019 261.705 257.019C252.705 229.359 258.705 177.949 314.705 154.949H314.805Z';
+
+onMounted(() => {
+  phTimer = setInterval(() => {
+    if (!input.value && document.activeElement?.id !== 'fp-input') {
+      phIdx = (phIdx + 1) % PLACEHOLDERS.length;
+      placeholder.value = PLACEHOLDERS[phIdx];
+    }
+  }, 3500);
+});
+
+onUnmounted(() => {
+  clearTimeout(eggTimer);
+  clearTimeout(timer);
+  clearInterval(matrixTimer);
+  clearInterval(phTimer);
+  clearInterval(enigmaTimer);
+});
 </script>
 
 <template>
@@ -61,25 +317,213 @@ onMounted(() => {
         type="text"
         autocomplete="off"
         spellcheck="false"
-        placeholder="Type anything…"
+        :placeholder="placeholder"
         class="mt-2 w-full rounded-md border border-line bg-background px-3.5 py-2.5 font-mono text-sm text-foreground outline-none transition-colors placeholder:text-faint focus:border-accent"
       />
 
       <p class="mono-label mt-5 text-faint">Fingerprint</p>
       <div
-        class="fingerprint mt-2 rounded-md border border-line bg-surface-dim p-4 text-[0.82rem] leading-loose"
+        class="fingerprint relative mt-2 min-h-[8rem] overflow-hidden rounded-md border p-4 text-[0.82rem] leading-loose transition-colors duration-300"
+        :class="eggBackground"
         aria-live="polite"
       >
-        <template v-if="groups.length">
+        <!-- MATRIX -->
+        <div v-if="activeEgg === 'matrix'" class="font-mono">
           <span
-            v-for="(g, i) in groups"
-            :key="i"
-            class="transition-colors"
-            :class="i % 4 === 3 ? 'text-accent2' : i % 4 === 1 ? 'text-accent' : 'text-foreground'"
-            >{{ g }}{{ i < groups.length - 1 ? ' ' : '' }}</span
+            v-for="(g, i) in matrixGroups"
+            :key="`m${i}-${matrixTick}`"
+            class="matrix-glyph inline-block"
+            :style="{ animationDelay: `${(i % 8) * 60}ms` }"
+            >{{ g }}{{ i < matrixGroups.length - 1 ? ' ' : '' }}</span
           >
+        </div>
+
+        <!-- REDACTED -->
+        <div v-else-if="activeEgg === 'redacted'" class="relative select-none">
+          <div class="font-mono text-black">
+            <span v-for="(g, i) in redactedGroups" :key="`r${i}`" class="opacity-90"
+              >{{ g }}{{ i < redactedGroups.length - 1 ? ' ' : '' }}</span
+            >
+          </div>
+          <div class="pointer-events-none absolute inset-0 flex items-center justify-center">
+            <span
+              class="egg-stamp rotate-[-14deg] rounded border-[3px] border-[#b91c1c] px-3 py-1 font-mono text-base font-black uppercase tracking-[0.3em] text-[#b91c1c]"
+              >Classified</span
+            >
+          </div>
+        </div>
+
+        <!-- DON'T PANIC -->
+        <div v-else-if="activeEgg === 'panic'" class="text-center">
+          <p
+            class="egg-panic-title font-sans text-2xl font-bold tracking-tight text-[#1a3a5c] md:text-3xl"
+          >
+            DON'T PANIC
+          </p>
+          <p class="mt-1 font-mono text-[0.7rem] text-[#7a5a1a]">
+            — in big, friendly letters on its cover
+          </p>
+        </div>
+
+        <!-- THUNDERBIRD -->
+        <div v-else-if="activeEgg === 'thunderbird'" class="relative flex h-10 items-center">
+          <div class="egg-bird flex items-center gap-3 whitespace-nowrap">
+            <svg
+              viewBox="0 0 750 750"
+              class="egg-bird-icon h-7 w-7 text-accent"
+              fill="currentColor"
+              aria-hidden="true"
+            >
+              <path :d="THUNDERBIRD_PATH" />
+            </svg>
+            <span class="font-mono text-sm text-accent">Powered by Thunderbird's wings.</span>
+          </div>
+        </div>
+
+        <!-- ASCII ARMOR -->
+        <div v-else-if="activeEgg === 'armor'" class="font-mono text-[0.7rem] leading-snug">
+          <div class="text-faint">-----BEGIN PGP MESSAGE-----</div>
+          <div class="my-1 break-all text-foreground/85">
+            {{ hex.slice(0, 48) }}<br />{{ hex.slice(48, 96) }}<br />{{ hex.slice(96) }}
+          </div>
+          <div class="text-faint">-----END PGP MESSAGE-----</div>
+        </div>
+
+        <!-- HAL 9000 -->
+        <div v-else-if="activeEgg === 'hal'" class="flex items-center gap-4">
+          <div class="hal-eye shrink-0"></div>
+          <div>
+            <p class="font-mono text-base font-bold tracking-wide text-[#ff1744]">I'M SORRY, DAVE.</p>
+            <p class="mt-0.5 font-mono text-xs text-[#ff1744]/70">I'm afraid I can't do that.</p>
+          </div>
+        </div>
+
+        <!-- DAVE BOWMAN (lockout terminal — full scene plays screenwide) -->
+        <div v-else-if="activeEgg === 'dave'" class="font-mono text-xs leading-snug">
+          <p class="text-cyan-300">&gt; Open the pod bay doors, HAL.</p>
+          <p class="mt-1.5 text-[#ff4757]/80">— transmission pending —</p>
+        </div>
+
+        <!-- POST-QUANTUM -->
+        <div v-else-if="activeEgg === 'pqc'" class="text-center font-sans leading-snug">
+          <p class="font-mono text-sm font-bold uppercase tracking-[0.25em] text-cyan-400 egg-pqc">
+            Harvest now.
+          </p>
+          <p
+            class="font-mono text-sm font-bold uppercase tracking-[0.25em] text-cyan-400 egg-pqc"
+            style="animation-delay: 0.35s"
+          >
+            Decrypt later.
+          </p>
+          <p class="mt-2 text-[0.7rem] text-cyan-300/70">— the post-quantum adversary is patient</p>
+        </div>
+
+        <!-- LIBREPGP -->
+        <div v-else-if="activeEgg === 'librepgp'" class="text-center font-sans leading-snug">
+          <p class="egg-librepgp text-xl font-bold tracking-tight text-gold-ink">LibrePGP</p>
+          <p class="mt-1 text-[0.7rem] italic text-gold-ink/80">— the open OpenPGP specification</p>
+          <p class="mt-1 font-mono text-[0.65rem] text-gold-ink/60">
+            brought to you by g10 · Intevation · Ribose
+          </p>
+        </div>
+
+        <!-- RIBOSE -->
+        <div v-else-if="activeEgg === 'ribose'" class="text-center font-sans leading-snug">
+          <p class="text-sm italic text-foreground">
+            "Open source is a development methodology; free software is a social movement."
+          </p>
+          <p class="mt-1.5 font-mono text-[0.7rem] text-faint">— Ribose · the people behind RNP</p>
+        </div>
+
+        <!-- PRIVACY -->
+        <div v-else-if="activeEgg === 'privacy'" class="text-center font-sans leading-snug">
+          <p class="text-sm italic text-foreground">
+            "Privacy is the power to selectively reveal oneself to the world."
+          </p>
+          <p class="mt-1.5 font-mono text-[0.7rem] text-faint">
+            — Eric Hughes · A Cypherpunk's Manifesto (1993)
+          </p>
+        </div>
+
+        <!-- DIFFIE–HELLMAN (paint-mixing key exchange) -->
+        <div v-else-if="activeEgg === 'dh'" class="dh-egg text-center">
+          <div class="flex items-center justify-center gap-3">
+            <span class="dh-can bg-rose-500" title="Alice's secret"></span>
+            <span class="font-mono text-faint">+</span>
+            <span class="dh-can bg-blue-500" title="Bob's secret"></span>
+            <span class="font-mono text-faint">→</span>
+            <span class="dh-can bg-purple-600 dh-shared" title="shared secret"></span>
+          </div>
+          <p class="mt-3 font-mono text-[0.65rem] text-purple-200/70">
+            Public exchange, private result. (Diffie–Hellman, 1976)
+          </p>
+        </div>
+
+        <!-- ONE-TIME PAD (plaintext ⊕ key = ciphertext, computed from input) -->
+        <div v-else-if="activeEgg === 'otp'" class="font-mono text-[0.7rem] leading-snug">
+          <div v-if="otpData" class="space-y-1">
+            <div class="flex gap-2">
+              <span class="w-5 shrink-0 font-bold text-emerald-400">P</span>
+              <span class="break-all text-emerald-50/90">{{ otpData.plain }}</span>
+            </div>
+            <div class="flex gap-2">
+              <span class="w-5 shrink-0 font-bold text-amber-400">K</span>
+              <span class="break-all text-emerald-50/90">{{ otpData.key }}</span>
+            </div>
+            <div class="flex gap-2">
+              <span class="w-5 shrink-0 font-bold text-rose-400">C</span>
+              <span class="break-all text-emerald-50/90">{{ otpData.cipher }}</span>
+            </div>
+          </div>
+          <p class="mt-2 text-center text-[0.65rem] text-emerald-200/80">
+            ⊕ — mathematically proven unbreakable. Use once.
+          </p>
+        </div>
+
+        <!-- ENIGMA (3-rotor stepping) -->
+        <div v-else-if="activeEgg === 'enigma'" class="text-center">
+          <div class="flex items-center justify-center gap-2">
+            <div v-for="(letter, i) in enigmaRotors" :key="i" class="enigma-rotor">
+              <span class="enigma-letter">{{ letter }}</span>
+            </div>
+          </div>
+          <p class="mt-3 font-mono text-[0.65rem] text-gray-400">
+            ³-rotor cipher · Wehrmacht, 1934–1945
+          </p>
+        </div>
+
+        <!-- PHIL ZIMMERMANN (PGP "munition" stamp, 1993–1996) -->
+        <div v-else-if="activeEgg === 'phil'" class="text-center">
+          <div class="phil-stamp egg-stamp-phil">
+            <span class="phil-stamp-text">Munition</span>
+            <span class="phil-stamp-sub">ITAR · US Customs · 1993–1996</span>
+          </div>
+          <p class="mt-3 font-mono text-[0.65rem] text-[#5a3a0a]">
+            PGP was a weapon. Zimmermann under investigation for 3 years.
+          </p>
+        </div>
+
+        <!-- DEFAULT FINGERPRINT -->
+        <template v-else>
+          <template v-if="groups.length">
+            <span
+              v-for="(g, i) in groups"
+              :key="i"
+              class="transition-colors"
+              :class="i % 4 === 3 ? 'text-accent2' : i % 4 === 1 ? 'text-accent' : 'text-foreground'"
+              >{{ g }}{{ i < groups.length - 1 ? ' ' : '' }}</span
+            >
+          </template>
+          <span v-else class="text-faint">···· ···· ···· ···· ···· ···· ···· ···· ···· ···· ···· ···· ···· ···· ···· ····</span>
         </template>
-        <span v-else class="text-faint">···· ···· ···· ···· ···· ···· ···· ····</span>
+
+        <!-- HEX WORD BADGE -->
+        <div
+          v-if="hexWord && !activeEgg"
+          class="egg-sparkle absolute right-2 top-2 rounded-full bg-gold/20 px-2 py-0.5 font-mono text-[0.65rem] font-bold uppercase tracking-wider text-gold-ink"
+        >
+          ✨ {{ hexWord }}
+        </div>
       </div>
 
       <div class="mt-4 flex flex-wrap items-center justify-between gap-3">
@@ -99,3 +543,176 @@ onMounted(() => {
     </div>
   </div>
 </template>
+
+<style scoped>
+.matrix-glyph {
+  color: #00ff41;
+  text-shadow: 0 0 6px #00ff41, 0 0 12px rgba(0, 255, 65, 0.4);
+  animation: matrix-flicker 0.35s steps(2, jump-none) infinite;
+}
+@keyframes matrix-flicker {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.55; }
+}
+
+.egg-stamp {
+  background: rgba(185, 28, 28, 0.08);
+  animation: stamp-in 0.5s cubic-bezier(0.5, -0.4, 0.4, 1.8) forwards;
+}
+@keyframes stamp-in {
+  0% { transform: rotate(-14deg) scale(2.6); opacity: 0; }
+  60% { transform: rotate(-14deg) scale(0.92); opacity: 1; }
+  100% { transform: rotate(-14deg) scale(1); opacity: 1; }
+}
+
+.egg-panic-title {
+  animation: panic-in 0.7s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+}
+@keyframes panic-in {
+  0% { transform: scale(0.3) rotate(-6deg); opacity: 0; letter-spacing: 0.4em; }
+  100% { transform: scale(1) rotate(0); opacity: 1; letter-spacing: normal; }
+}
+
+.egg-bird {
+  animation: bird-fly 2.6s cubic-bezier(0.4, 0, 0.2, 1) forwards;
+}
+.egg-bird-icon {
+  transform-origin: center;
+  animation: bird-flap 0.28s ease-in-out infinite;
+}
+@keyframes bird-fly {
+  0% { transform: translateX(-110%); }
+  55% { transform: translateX(35%); }
+  100% { transform: translateX(110%); }
+}
+@keyframes bird-flap {
+  0%, 100% { transform: scaleY(1) rotate(0deg); }
+  50% { transform: scaleY(0.7) rotate(-3deg); }
+}
+
+.egg-sparkle {
+  animation: sparkle 1.6s ease-in-out infinite;
+}
+@keyframes sparkle {
+  0%, 100% { opacity: 0.75; transform: scale(1); }
+  50% { opacity: 1; transform: scale(1.1); }
+}
+
+.hal-eye {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 35% 35%, #ff6b6b 0%, #ff1744 40%, #8b0000 100%);
+  box-shadow: 0 0 16px #ff1744, inset 0 0 10px rgba(0, 0, 0, 0.5);
+  animation: hal-pulse 2.4s ease-in-out infinite;
+}
+@keyframes hal-pulse {
+  0%, 100% { box-shadow: 0 0 16px #ff1744, inset 0 0 10px rgba(0, 0, 0, 0.5); }
+  50% { box-shadow: 0 0 28px #ff1744, inset 0 0 10px rgba(0, 0, 0, 0.5); }
+}
+
+.egg-pqc {
+  animation: pqc-flicker 2.2s ease-in-out infinite;
+}
+@keyframes pqc-flicker {
+  0%, 100% { opacity: 1; text-shadow: 0 0 8px rgba(34, 211, 238, 0.5); }
+  50% { opacity: 0.85; text-shadow: 0 0 14px rgba(34, 211, 238, 0.9); }
+}
+
+.egg-librepgp {
+  animation: librepgp-glow 2.6s ease-in-out infinite;
+}
+@keyframes librepgp-glow {
+  0%, 100% { text-shadow: 0 0 8px color-mix(in oklab, var(--gold) 60%, transparent); }
+  50% { text-shadow: 0 0 16px color-mix(in oklab, var(--gold) 90%, transparent); }
+}
+
+/* Diffie–Hellman paint cans */
+.dh-can {
+  display: inline-block;
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 50%;
+  box-shadow: inset -3px -4px 6px rgba(0, 0, 0, 0.35), 0 2px 6px rgba(0, 0, 0, 0.25);
+}
+.dh-shared {
+  animation: dh-shimmer 2.4s ease-in-out infinite;
+}
+@keyframes dh-shimmer {
+  0%, 100% { filter: brightness(1) saturate(1); }
+  50% { filter: brightness(1.25) saturate(1.3); }
+}
+
+/* Enigma rotors */
+.enigma-rotor {
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 0.375rem;
+  background: linear-gradient(180deg, #2a2a2c 0%, #1a1a1c 50%, #0a0a0c 100%);
+  border: 1px solid #3a3a3c;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.06),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.5),
+    0 2px 6px rgba(0, 0, 0, 0.5);
+}
+.enigma-letter {
+  font-family: var(--font-mono);
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: #d0d0d4;
+  text-shadow: 0 0 8px rgba(255, 255, 255, 0.15);
+}
+
+/* Phil Zimmermann rubber stamp */
+.phil-stamp {
+  display: inline-block;
+  border: 3px double #b91c1c;
+  padding: 0.4rem 1.1rem;
+  background: rgba(185, 28, 28, 0.08);
+}
+.phil-stamp-text {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: 1.25rem;
+  font-weight: 900;
+  letter-spacing: 0.25em;
+  text-transform: uppercase;
+  color: #b91c1c;
+}
+.phil-stamp-sub {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: 0.55rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: rgba(185, 28, 28, 0.7);
+  margin-top: 0.25rem;
+}
+.egg-stamp-phil {
+  animation: phil-stamp 0.5s cubic-bezier(0.5, -0.4, 0.4, 1.8) forwards;
+}
+@keyframes phil-stamp {
+  0% { transform: rotate(-8deg) scale(3); opacity: 0; filter: blur(4px); }
+  60% { transform: rotate(-8deg) scale(0.92); opacity: 1; filter: blur(0); }
+  100% { transform: rotate(-8deg) scale(1); opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .matrix-glyph,
+  .egg-stamp,
+  .egg-panic-title,
+  .egg-bird,
+  .egg-bird-icon,
+  .egg-sparkle,
+  .hal-eye,
+  .egg-pqc,
+  .egg-librepgp,
+  .dh-shared,
+  .egg-stamp-phil {
+    animation: none;
+  }
+}
+</style>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -120,7 +120,7 @@ const jsonLd = {
     </main>
     <SiteFooter />
     <SiteSearch client:only="vue" />
-    <EasterEggs client:load />
+    <EasterEggs client:only="vue" />
     <script>
       // Progressive enhancement: copy button on every code block.
       const enhanceCopy = () => {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -90,7 +90,7 @@ const releaseDate = release.publishedAt.slice(0, 10);
           </div>
         </div>
         <div class="lg:justify-self-end">
-          <FingerprintPlayground client:visible />
+          <FingerprintPlayground client:visible class="w-full max-w-md lg:w-[30rem]" />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

A catalog of secret keywords in the home-page fingerprint playground turns the live SHA-256 box into a small stage, plus two screenwide cinematic scenes for HAL 9000 and Dave Bowman. Eggs auto-clear after 5–11s and respect `prefers-reduced-motion`.

**In-box eggs** (type into the fingerprint input on `/`):
- `matrix` / `neo` → green Matrix-style glyph regen + flicker
- `snowden` / `nsa` / `prism` → ████ redaction bars + CLASSIFIED stamp
- `42` / `don't panic` → DON'T PANIC on a Hitchhiker's-Guide cream bg
- `thunderbird` → bird silhouette flies across with a flap animation
- `openpgp` / `4880` → ASCII-armored PGP MESSAGE block
- `hal` / `9000` / `monolith` → inline HAL indicator; fires screenwide scene
- `dave` / `pod bay doors` → inline lockout terminal; fires screenwide scene
- `pqc` / `quantum` / `9980` → "Harvest now. Decrypt later." cyan flicker
- `librepgp` → LibrePGP branding ("brought to you by g10 · Intevation · Ribose")
- `ribose` → open-source quote attributed to Ribose
- `privacy` → Eric Hughes, A Cypherpunk's Manifesto (1993)
- `dh` → Diffie–Hellman paint-mixing (3 cans)
- `otp` → one-time pad: actual XOR of input with a freshly-generated random key
- `enigma` → 3 rotors, Enigma-style stepping every 600ms
- `phil` / `zimmermann` → "MUNITION" rubber stamp, ITAR 1993–1996

**Passive**: SHA-256 starting with `DEAD` / `BEEF` / `CAFE` / etc. surfaces a gold ✨ badge in the corner of the box.

**Default seed value**: `'LibrePGP'` is exempt from egg detection until the user actually changes the input (a `touched` ref gates the watcher).

**Hex rain / hero replay from inside the input**: typing `rnp`, `pgp`, or `decrypt` into the fingerprint box now also fires the same full-screen effects that the global keypress listener does.

**Screenwide scenes** (EasterEggs.vue, dispatched via `rnp:hal-scene` / `rnp:dave-scene` window events):
- HAL scene: full-viewport layered CSS HAL eye (dark housing → red ring → glowing lens → specular shine), **eye tracks the cursor** with eased ±14px parallax, random HAL quote types out at ~42ms/char with a blinking █ cursor, "Click anywhere to disconnect"
- Dave scene: Discovery One pod-bay intercom console, the actual movie dialogue plays out line by line (Dave cyan with `>` prefix, HAL red no prefix) with staggered fade-ins, "Click anywhere to abort transmission"

**Console discoverability**:
- `help()` / `rnp.help()` prints the full egg catalog; returns the text
- One-time-per-session hint on first devtools open (`sessionStorage['rnp:help-hinted']`)

**Layout / SSR**:
- `EasterEggs` switched to `client:only="vue"` — Teleport+SSR markers disagree on hydration; the component is 100% client-side behavior (listeners, animations, dynamic scenes) so SSR added nothing anyway
- `FingerprintPlayground` root capped to `max-w-md lg:w-[30rem]` and the box given `min-h-[8rem]` so it no longer grows/shrinks between empty, hex-display, and every egg state
- Deeply nested `:class` ternary refactored into an `eggBackground` computed

**Light-mode readability**: OTP hex value spans now use a fixed light color so they stay readable on the dark green bg in light mode (was theme-variable).

## Test plan

- [x] `curl http://localhost:4322/` — page renders, no SSR errors, no `teleport start` markers in body
- [x] `EasterEggs` mounted `client:only="vue"` (no hydration mismatch)
- [x] `help()` / `rnp.help()` defined on `window`, help text printed + returned
- [x] `decrypt` watcher wired in FingerprintPlayground
- [ ] Visual review of each egg on a real screen, both light + dark themes
- [ ] Mobile sanity (no horizontal scroll, scenes dismiss on tap)
