### PR TITLE
feat: 'encrypt' keyword scrambles hero text (inverse of 'decrypt')

### DIFF
--- a/src/components/vue/EasterEggs.vue
+++ b/src/components/vue/EasterEggs.vue
@@ -246,6 +246,10 @@ const onKey = (e: KeyboardEvent) => {
     word = '';
     window.dispatchEvent(new CustomEvent('rnp:replay-hero'));
     toast('Replaying decryption…');
+  } else if (word.endsWith('encrypt')) {
+    word = '';
+    window.dispatchEvent(new CustomEvent('rnp:encrypt-hero'));
+    toast('Encrypting…');
   } else if (word.endsWith('rnp') || word.endsWith('pgp')) {
     word = '';
     hexRain();
@@ -370,27 +374,29 @@ const onDaveReq = () => playDaveScene();
 
 /** `help()` in the console — list every egg. */
 const HELP_TEXT = `Type anywhere on the page (not in inputs):
-  rnp · pgp       →  oracle rain (philosophy)
-  decrypt         →  replay hero decryption
+  rnp · pgp            →  oracle rain (philosophy)
+  decrypt              →  replay hero decryption (garbage → text)
+  encrypt              →  scramble the hero text (text → garbage → text)
 
 In the fingerprint box (home page):
-  decrypt         →  also replays hero decryption
-  42              →  DON'T PANIC
-  dave            →  open the pod bay doors (screenwide)
-  dh              →  Diffie–Hellman paint exchange
-  enigma          →  ³-rotor cipher, live stepping
-  hal · 9000      →  HAL 9000 (screenwide)
-  librepgp        →  the open OpenPGP spec
-  matrix          →  wake up, Neo
-  openpgp · 4880  →  ASCII-armored message
-  otp             →  one-time pad (XOR of your input)
-  phil            →  PGP was a munition (1993–1996)
-  pqc · quantum   →  harvest now, decrypt later
-  privacy         →  cypherpunk's manifesto
-  ribose          →  who's behind RNP
-  snowden · nsa   →  classified
-  thunderbird     →  powered by Thunderbird's wings
-  rnp · pgp       →  also triggers oracle rain
+  decrypt              →  same — replay hero decryption
+  encrypt              →  same — scramble the hero text
+  42                   →  DON'T PANIC
+  dave                 →  open the pod bay doors (screenwide)
+  dh                   →  Diffie–Hellman paint exchange
+  enigma               →  ³-rotor cipher, live stepping
+  hal · 9000           →  HAL 9000 (screenwide)
+  librepgp             →  the open OpenPGP spec
+  matrix               →  wake up, Neo
+  openpgp · 4880       →  ASCII-armored message
+  otp                  →  one-time pad (XOR of your input)
+  phil                 →  PGP was a munition (1993–1996)
+  pqc · quantum        →  harvest now, decrypt later
+  privacy              →  cypherpunk's manifesto
+  ribose               →  who's behind RNP
+  snowden · nsa        →  classified
+  thunderbird          →  powered by Thunderbird's wings
+  rnp · pgp            →  also triggers oracle rain
 
 Type help() or rnp.help() to reprint.`;
 

--- a/src/components/vue/FingerprintPlayground.vue
+++ b/src/components/vue/FingerprintPlayground.vue
@@ -209,15 +209,21 @@ watch(input, (val) => {
   }
 });
 
-/* Typing 'decrypt' in the input also replays the hero decryption animation. */
-let lastDecryptInput = '';
+/* Typing 'decrypt' or 'encrypt' in the input drives the hero animation:
+   decrypt → garbage settles to readable; encrypt → readable scrambles
+   (then auto-settles back so the page isn't stuck). Substring match so
+   either word fires whether appended to the default seed, typed alone,
+   or part of a longer word. Decrypt wins if both are present. */
+let lastHeroInput = '';
 watch(input, (val) => {
-  const matches = /\bdecrypt\b/i.test(val);
-  if (matches && val !== lastDecryptInput) {
-    lastDecryptInput = val;
-    window.dispatchEvent(new CustomEvent('rnp:replay-hero'));
-  } else if (!matches) {
-    lastDecryptInput = '';
+  let evt: 'rnp:replay-hero' | 'rnp:encrypt-hero' | null = null;
+  if (/decrypt/i.test(val)) evt = 'rnp:replay-hero';
+  else if (/encrypt/i.test(val)) evt = 'rnp:encrypt-hero';
+  if (evt && val !== lastHeroInput) {
+    lastHeroInput = val;
+    window.dispatchEvent(new CustomEvent(evt));
+  } else if (!evt) {
+    lastHeroInput = '';
   }
 });
 

--- a/src/components/vue/HeroDecrypt.vue
+++ b/src/components/vue/HeroDecrypt.vue
@@ -7,6 +7,8 @@ const GLYPHS = '0123456789ABCDEF$#@%&*+=~';
 const display = ref(props.text);
 let raf = 0;
 
+const isPunct = (ch: string) => ch === ' ' || ch === '.' || ch === ',';
+
 const run = () => {
   cancelAnimationFrame(raf);
   const text = props.text;
@@ -21,11 +23,37 @@ const run = () => {
     let out = text.slice(0, settled);
     for (let i = settled; i < total; i++) {
       const ch = text[i];
-      out += ch === ' ' || ch === '.' || ch === ',' ? ch : GLYPHS[Math.floor(Math.random() * GLYPHS.length)];
+      out += isPunct(ch) ? ch : GLYPHS[Math.floor(Math.random() * GLYPHS.length)];
     }
     display.value = out;
     if (t < 1) raf = requestAnimationFrame(tick);
     else display.value = text;
+  };
+  raf = requestAnimationFrame(tick);
+};
+
+/** Encrypt: scramble wave sweeps L→R, leaving the text fully mangled.
+ *  Stays mangled — type 'decrypt' (or refresh) to restore. */
+const runEncrypt = () => {
+  cancelAnimationFrame(raf);
+  const text = props.text;
+  const total = text.length;
+  const duration = 1400;
+  const start = performance.now();
+
+  const tick = (now: number) => {
+    const t = Math.min(1, (now - start) / duration);
+    const edge = Math.floor(total * t * t * (3 - 2 * t));
+    let out = '';
+    for (let i = 0; i < total; i++) {
+      const ch = text[i];
+      out += i < edge && !isPunct(ch)
+        ? GLYPHS[Math.floor(Math.random() * GLYPHS.length)]
+        : ch;
+    }
+    display.value = out;
+    if (t < 1) raf = requestAnimationFrame(tick);
+    // else: final state is fully scrambled — leave it
   };
   raf = requestAnimationFrame(tick);
 };
@@ -35,13 +63,15 @@ const reducedMotion = () => matchMedia('(prefers-reduced-motion: reduce)').match
 onMounted(() => {
   // Passive auto-play respects reduced-motion…
   if (!reducedMotion()) run();
-  // …but a user explicitly typing 'decrypt' always gets the replay.
+  // …but a user explicitly typing 'decrypt' or 'encrypt' always gets the effect.
   window.addEventListener('rnp:replay-hero', run);
+  window.addEventListener('rnp:encrypt-hero', runEncrypt);
 });
 
 onUnmounted(() => {
   cancelAnimationFrame(raf);
   window.removeEventListener('rnp:replay-hero', run);
+  window.removeEventListener('rnp:encrypt-hero', runEncrypt);
 });
 </script>
 


### PR DESCRIPTION
## Summary

`encrypt` now drives a separate, inverse hero animation. Previously both `encrypt` and `decrypt` fired the same `rnp:replay-hero` event (decryption scramble). They're now distinct:

- **`decrypt`** → `rnp:replay-hero`: garbage settles L→R into readable text (existing behavior)
- **`encrypt`** → `rnp:encrypt-hero`: readable text scrambles L→R and **stays mangled** — type `decrypt` (or refresh) to restore

One-way semantics match the metaphor: encryption without the key leaves ciphertext opaque. Refreshing the page still auto-plays the decrypt animation on mount via the existing reduced-motion-aware `run()` call.

## Changes

- **`HeroDecrypt.vue`**: new `runEncrypt()` does the scramble wave and stops at the final mangled state (no auto-decrypt cycle). Listener registered for `rnp:encrypt-hero`.
- **`FingerprintPlayground.vue`**: input watcher dispatches `rnp:replay-hero` for `/decrypt/i` or `rnp:encrypt-hero` for `/encrypt/i`. Decrypt wins if both appear. Substring match (no word boundaries) so either fires appended to the default `LibrePGP` seed, standalone, or inside a longer word. The decrypt regex was also loosened from `/\bdecrypt\b/` to `/decrypt/` for the same reason.
- **`EasterEggs.vue`**: global keypress (anywhere outside inputs) now branches on `endsWith('decrypt')` vs `endsWith('encrypt')`, with distinct toasts (`Replaying decryption…` / `Encrypting…`). Help text (`rnp.help()`) lists them as separate entries with their distinct effects.

## Test plan

- [x] `curl http://localhost:4322/` — page renders cleanly
- [x] `HeroDecrypt` listens for both `rnp:replay-hero` and `rnp:encrypt-hero`
- [x] FingerprintPlayground dispatches the correct event per keyword
- [x] EasterEggs global keypress branches correctly
- [x] Help text shows two separate entries
- [ ] Visual review: type `encrypt` in the fingerprint box → text scrambles and stays; type `decrypt` → text settles back
