### PR TITLE
fix: exclude autocrypt.org from link check (times out from CI)

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -18,4 +18,7 @@ exclude = [
   '^https://docs\.redhat\.com/',
   # Cirrus CI blocks non-browser TLS clients.
   '^https://cirrus-ci\.com/',
+  # autocrypt.org has been intermittently unreachable (times out from CI);
+  # the Autocrypt project itself appears inactive.
+  '^https://autocrypt\.org/',
 ]


### PR DESCRIPTION
## Summary

The lychee link-check job has been failing on `main` since the last merge — two consecutive failed runs (2026-07-22 and 2026-07-23). The only failure is a single timeout: `https://autocrypt.org/`, linked from the 2024-05-03 RNP 0.17.1 release post.

```
[TIMEOUT] https://autocrypt.org/ (at 227:21) | Request timed out
```

`curl` from this machine also times out (8s and 20s). The Autocrypt project itself appears inactive, so this is unlikely to recover on its own.

Adding `^https://autocrypt\.org/$` to the lychee exclude list, matching the existing pattern for sites that block or time out automated checkers (Red Hat, Cirrus CI).

## Test plan

- [x] Confirmed the failure is the only error in run 29976046534 (2881 total, 2721 successful, 1 timeout, 0 errors)
- [x] Local `curl` repros the timeout
- [ ] Next CI run after merge should go green
