### PR TITLE
fix: point Autocrypt link at www.autocrypt.org (apex times out)

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -18,7 +18,4 @@ exclude = [
   '^https://docs\.redhat\.com/',
   # Cirrus CI blocks non-browser TLS clients.
   '^https://cirrus-ci\.com/',
-  # autocrypt.org has been intermittently unreachable (times out from CI);
-  # the Autocrypt project itself appears inactive.
-  '^https://autocrypt\.org/',
 ]

--- a/src/content/blog/2024-05-03-rnp-release-0-17-1.adoc
+++ b/src/content/blog/2024-05-03-rnp-release-0-17-1.adoc
@@ -139,7 +139,7 @@ encountering packets with unknown versions.
 * Automatic backend feature detection during the build process enhances system compatibility and setup.
 
 * Added support for importing and exporting base64-encoded keys, particularly
-useful for https://autocrypt.org/[Autocrypt] headers.
+useful for https://www.autocrypt.org/[Autocrypt] headers.
 
 * Implemented a default 2-year key expiration time for better key lifecycle management.
 


### PR DESCRIPTION
## Summary

The apex domain (`https://autocrypt.org/`) was timing out from CI and from my local machine. The `www` variant (`https://www.autocrypt.org/`) returns **HTTP/2 200** — confirmed via curl. Updating the blog post link to use the `www` form, and reverting the temporary exclusion added in #98 now that the link actually resolves.

Follow-up to PR #98.

## Test plan

- [x] `curl -sI --max-time 10 https://www.autocrypt.org/` → `HTTP/2 200`
- [x] Apex `https://autocrypt.org/` still times out (so the previous exclusion was a real symptom, not a flake)
- [ ] Next CI run should go green without needing the exclusion
