### PR TITLE
refactor: deepen four modules surfaced by the architecture review

### DIFF
--- a/scripts/fetch-sources.mjs
+++ b/scripts/fetch-sources.mjs
@@ -12,11 +12,12 @@
  * Existing vendor clones are reused (delete vendor/ to force a refresh).
  * Network failures are warnings, not errors — docs pages degrade gracefully.
  */
-import { existsSync, mkdirSync, readdirSync, readFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readdirSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { parse as parseYaml } from 'yaml';
+import { parseFrontmatter } from '../src/lib/frontmatter.mjs';
+import { RNP_EXTRA_SPARSE } from '../src/lib/vendor-source.mjs';
 
 const root = join(dirname(fileURLToPath(import.meta.url)), '..');
 const vendorDir = join(root, 'vendor');
@@ -24,14 +25,8 @@ const softwareDir = join(root, 'src/content/software');
 
 /** Extra files to check out per product, gitignore-style sparse patterns. */
 const EXTRA_PATHS = {
-  rnp: ['/src/rnp/rnp.1.adoc', '/src/rnpkeys/rnpkeys.1.adoc', '/src/lib/librnp.3.adoc'],
+  rnp: RNP_EXTRA_SPARSE,
 };
-
-function frontMatter(file) {
-  const raw = readFileSync(file, 'utf8');
-  const m = raw.match(/^---\r?\n([\s\S]*?)\r?\n---/);
-  return m ? (parseYaml(m[1]) ?? {}) : {};
-}
 
 function run(args, cwd) {
   execFileSync('git', args, { cwd, stdio: 'pipe' });
@@ -40,7 +35,7 @@ function run(args, cwd) {
 let failures = 0;
 
 for (const file of readdirSync(softwareDir).filter((f) => f.endsWith('.md'))) {
-  const fm = frontMatter(join(softwareDir, file));
+  const fm = parseFrontmatter(join(softwareDir, file)).frontMatter;
   if (!fm.docs_repo) continue;
 
   const name = file.replace(/\.md$/, '');

--- a/src/components/vue/EasterEggs.vue
+++ b/src/components/vue/EasterEggs.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { nextTick, onMounted, onUnmounted, ref, watch } from 'vue';
+import { dispatch, RNP_EVENTS, RNP_STORAGE } from '@/lib/events';
 
 const toastMsg = ref('');
 const toastEl = ref<HTMLElement | null>(null);
@@ -244,11 +245,11 @@ const onKey = (e: KeyboardEvent) => {
   word = (word + k).slice(-12);
   if (word.endsWith('decrypt')) {
     word = '';
-    window.dispatchEvent(new CustomEvent('rnp:replay-hero'));
+    dispatch(RNP_EVENTS.replayHero);
     toast('Replaying decryption…');
   } else if (word.endsWith('encrypt')) {
     word = '';
-    window.dispatchEvent(new CustomEvent('rnp:encrypt-hero'));
+    dispatch(RNP_EVENTS.encryptHero);
     toast('Encrypting…');
   } else if (word.endsWith('rnp') || word.endsWith('pgp')) {
     word = '';
@@ -408,16 +409,16 @@ const showEggHelp = () => {
 
 onMounted(() => {
   window.addEventListener('keydown', onKey);
-  window.addEventListener('rnp:hex-rain', onHexRainReq);
-  window.addEventListener('rnp:hal-scene', onHalReq);
-  window.addEventListener('rnp:dave-scene', onDaveReq);
+  window.addEventListener(RNP_EVENTS.hexRain, onHexRainReq);
+  window.addEventListener(RNP_EVENTS.halScene, onHalReq);
+  window.addEventListener(RNP_EVENTS.daveScene, onDaveReq);
 
   window.rnp = window.rnp || {};
   window.rnp.help = showEggHelp;
   if (typeof window.help === 'undefined') window.help = showEggHelp;
 
-  if (!sessionStorage.getItem('rnp:help-hinted')) {
-    sessionStorage.setItem('rnp:help-hinted', '1');
+  if (!sessionStorage.getItem(RNP_STORAGE.helpHinted)) {
+    sessionStorage.setItem(RNP_STORAGE.helpHinted, '1');
     console.log(
       '%c👋 psst — type %chelp()%c to see the easter eggs',
       'color:#888;font-style:italic;',
@@ -428,9 +429,9 @@ onMounted(() => {
 });
 onUnmounted(() => {
   window.removeEventListener('keydown', onKey);
-  window.removeEventListener('rnp:hex-rain', onHexRainReq);
-  window.removeEventListener('rnp:hal-scene', onHalReq);
-  window.removeEventListener('rnp:dave-scene', onDaveReq);
+  window.removeEventListener(RNP_EVENTS.hexRain, onHexRainReq);
+  window.removeEventListener(RNP_EVENTS.halScene, onHalReq);
+  window.removeEventListener(RNP_EVENTS.daveScene, onDaveReq);
   clearTimeout(toastTimer);
   clearHalTimers();
   clearDaveTimers();

--- a/src/components/vue/FingerprintPlayground.vue
+++ b/src/components/vue/FingerprintPlayground.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue';
 import CopyButton from './CopyButton.vue';
+import { dispatch, RNP_EVENTS } from '@/lib/events';
+import { EGG_REGISTRY } from './fingerprint/registry';
+import type { EggDef } from './fingerprint/types';
 
 const input = ref('LibrePGP');
 const hex = ref('');
@@ -31,225 +34,20 @@ const groups = computed(() => (hex.value ? (hex.value.match(/.{1,4}/g) ?? []) : 
 const keyId = computed(() => (hex.value ? hex.value.slice(-16) : ''));
 const fingerprintText = computed(() => groups.value.join(' '));
 
-let timer: ReturnType<typeof setTimeout> | undefined;
+let hashTimer: ReturnType<typeof setTimeout> | undefined;
 watch(input, () => {
-  clearTimeout(timer);
-  timer = setTimeout(update, 120);
-});
-
-onMounted(() => {
-  supported.value = typeof crypto !== 'undefined' && !!crypto.subtle;
-  update();
+  clearTimeout(hashTimer);
+  hashTimer = setTimeout(update, 120);
 });
 
 /* =========================== EASTER EGGS =========================== */
-type Egg =
-  | 'matrix'
-  | 'redacted'
-  | 'panic'
-  | 'thunderbird'
-  | 'armor'
-  | 'hal'
-  | 'dave'
-  | 'pqc'
-  | 'librepgp'
-  | 'ribose'
-  | 'privacy'
-  | 'dh'
-  | 'otp'
-  | 'enigma'
-  | 'phil'
-  | null;
-
-const EGGS: { trigger: RegExp; egg: Exclude<Egg, null> }[] = [
-  { trigger: /\b(matrix|neo|wake\s*up|mr\.?\s*anderson)\b/i, egg: 'matrix' },
-  { trigger: /\b(snowden|nsa|prism|classified|top\s*secret|redact(ed)?)\b/i, egg: 'redacted' },
-  { trigger: /\b(42|don'?t\s*panic|hitchhiker|arthur\s*dent)\b/i, egg: 'panic' },
-  { trigger: /\bthunderbird\b/i, egg: 'thunderbird' },
-  { trigger: /\b(pgp\s*message|ascii\s*armor|openpgp|4880)\b/i, egg: 'armor' },
-  { trigger: /\b(hal(\s*9000)?|hal9000|9000|monolith|space\s*odyssey|2001)\b/i, egg: 'hal' },
-  { trigger: /\b(dave(\s*bowman)?|bowman|pod\s*bay\s*doors?)\b/i, egg: 'dave' },
-  { trigger: /\b(pqc|post[-\s]*quantum|quantum|9980)\b/i, egg: 'pqc' },
-  { trigger: /\blibrepgp\b/i, egg: 'librepgp' },
-  { trigger: /\bribose\b/i, egg: 'ribose' },
-  { trigger: /\bprivacy\b/i, egg: 'privacy' },
-  { trigger: /\b(dh|diffie[\s-]*hellman)\b/i, egg: 'dh' },
-  { trigger: /\b(otp|one[\s-]*time[\s-]*pad|vernam)\b/i, egg: 'otp' },
-  { trigger: /\benigma\b/i, egg: 'enigma' },
-  { trigger: /\b(phil|zimmermann|munitions?)\b/i, egg: 'phil' },
-];
-
-const EGG_DURATIONS: Record<Exclude<Egg, null>, number> = {
-  matrix: 5000,
-  redacted: 5000,
-  panic: 5000,
-  thunderbird: 5000,
-  armor: 5000,
-  hal: 9000,
-  dave: 11000,
-  pqc: 5000,
-  librepgp: 5000,
-  ribose: 5000,
-  privacy: 5000,
-  dh: 6000,
-  otp: 6000,
-  enigma: 6000,
-  phil: 6000,
-};
-
-const eggBackground = computed(() => {
-  switch (activeEgg.value) {
-    case 'matrix': return 'border-emerald-500/40 bg-[#00150a]';
-    case 'redacted': return 'border-red-900/60 bg-black';
-    case 'panic': return 'border-amber-500/50 bg-[#fdf6e3]';
-    case 'hal': return 'border-[#ff1744]/40 bg-[#1a0606]';
-    case 'dave': return 'border-cyan-900/50 bg-[#040810]';
-    case 'pqc': return 'border-cyan-500/40 bg-[#061a1f]';
-    case 'dh': return 'border-purple-500/40 bg-[#0e0420]';
-    case 'otp': return 'border-emerald-500/40 bg-[#021810]';
-    case 'enigma': return 'border-gray-500/40 bg-[#0a0a0c]';
-    case 'phil': return 'border-amber-700/40 bg-[#f5edd6]';
-    case 'librepgp': return 'border-gold/50 bg-[color-mix(in_oklab,var(--gold)_14%,var(--surface-dim))]';
-    default:
-      return hexWord.value
-        ? 'border-gold/40 bg-[color-mix(in_oklab,var(--gold)_10%,var(--surface-dim))]'
-        : 'border-line bg-surface-dim';
-  }
-});
-
-const activeEgg = ref<Egg>(null);
+const activeEgg = ref<EggDef | null>(null);
 let eggTimer: ReturnType<typeof setTimeout> | undefined;
 
 const initialValue = 'LibrePGP';
 const touched = ref(false);
 
-/* OTP egg: plaintext (input) + random key + XOR ciphertext, snapshotted once. */
-const otpData = ref<{ plain: string; key: string; cipher: string } | null>(null);
-
-/* Enigma egg: 3 rotor letters, stepping every 600ms while active. */
-const enigmaRotors = ref<string[]>(['R', 'N', 'P']);
-let enigmaTimer: ReturnType<typeof setInterval> | undefined;
-
-watch(input, (val, oldVal) => {
-  if (!touched.value && oldVal === initialValue && val !== initialValue) touched.value = true;
-  clearTimeout(eggTimer);
-  if (val === initialValue && !touched.value) {
-    activeEgg.value = null;
-    return;
-  }
-  const match = EGGS.find(({ trigger }) => trigger.test(val));
-  if (match) {
-    activeEgg.value = match.egg;
-    eggTimer = setTimeout(
-      () => {
-        if (activeEgg.value === match.egg) activeEgg.value = null;
-      },
-      EGG_DURATIONS[match.egg],
-    );
-  } else {
-    activeEgg.value = null;
-  }
-});
-
-/* HAL & Dave eggs kick off screenwide scenes (rendered by EasterEggs.vue).
-   The inline egg below is just a small "establishing" indicator; the real
-   payload is the full-viewport overlay dispatched here. */
-watch(activeEgg, (egg) => {
-  if (egg === 'hal') window.dispatchEvent(new CustomEvent('rnp:hal-scene'));
-  else if (egg === 'dave') window.dispatchEvent(new CustomEvent('rnp:dave-scene'));
-
-  /* OTP: snapshot input as plaintext the moment the egg fires, generate a
-     random key of equal length, compute ciphertext = P ⊕ K. */
-  if (egg === 'otp' && input.value) {
-    const textBytes = new TextEncoder().encode(input.value);
-    const keyBytes = new Uint8Array(textBytes.length);
-    crypto.getRandomValues(keyBytes);
-    const cipherBytes = new Uint8Array(textBytes.length);
-    for (let i = 0; i < textBytes.length; i++) cipherBytes[i] = textBytes[i] ^ keyBytes[i];
-    const toHex = (b: Uint8Array) =>
-      Array.from(b)
-        .map((x) => x.toString(16).padStart(2, '0').toUpperCase())
-        .join(' ');
-    otpData.value = {
-      plain: toHex(textBytes),
-      key: toHex(keyBytes),
-      cipher: toHex(cipherBytes),
-    };
-  } else if (egg !== 'otp') {
-    otpData.value = null;
-  }
-
-  /* Enigma: 3 rotors stepping Enigma-style every 600ms (rightmost first,
-     carrying left when it wraps past Z). */
-  clearInterval(enigmaTimer);
-  if (egg === 'enigma') {
-    enigmaTimer = setInterval(() => {
-      const next = [...enigmaRotors.value];
-      for (let i = next.length - 1; i >= 0; i--) {
-        const c = next[i].charCodeAt(0);
-        const shifted = ((c - 65 + 1) % 26) + 65;
-        next[i] = String.fromCharCode(shifted);
-        if (shifted !== 65) break;
-      }
-      enigmaRotors.value = next;
-    }, 600);
-  }
-});
-
-/* Typing 'rnp' or 'pgp' in the input also kicks off the full-screen hex rain
-   (same effect as the global key listener — wired up in EasterEggs.vue). */
-let lastRainInput = '';
-watch(input, (val) => {
-  const matches = /\b(rnp|pgp)\b/i.test(val);
-  if (matches && val !== lastRainInput) {
-    lastRainInput = val;
-    window.dispatchEvent(new CustomEvent('rnp:hex-rain'));
-  } else if (!matches) {
-    lastRainInput = '';
-  }
-});
-
-/* Typing 'decrypt' or 'encrypt' in the input drives the hero animation:
-   decrypt → garbage settles to readable; encrypt → readable scrambles
-   (then auto-settles back so the page isn't stuck). Substring match so
-   either word fires whether appended to the default seed, typed alone,
-   or part of a longer word. Decrypt wins if both are present. */
-let lastHeroInput = '';
-watch(input, (val) => {
-  let evt: 'rnp:replay-hero' | 'rnp:encrypt-hero' | null = null;
-  if (/decrypt/i.test(val)) evt = 'rnp:replay-hero';
-  else if (/encrypt/i.test(val)) evt = 'rnp:encrypt-hero';
-  if (evt && val !== lastHeroInput) {
-    lastHeroInput = val;
-    window.dispatchEvent(new CustomEvent(evt));
-  } else if (!evt) {
-    lastHeroInput = '';
-  }
-});
-
-/* Matrix rain glyphs — regenerate on a tick so they feel alive. */
-const matrixTick = ref(0);
-let matrixTimer: ReturnType<typeof setInterval> | undefined;
-const MATRIX_POOL = '0123456789ABCEFｱｲｳｴｵｶｷｸｹｺｻｼｽｾｿﾀﾁﾂ';
-const matrixGroups = computed(() => {
-  void matrixTick.value;
-  if (activeEgg.value !== 'matrix') return [];
-  return Array.from({ length: 16 }, () =>
-    Array.from({ length: 4 }, () => MATRIX_POOL[Math.floor(Math.random() * MATRIX_POOL.length)]).join(
-      '',
-    ),
-  );
-});
-watch(activeEgg, (egg) => {
-  clearInterval(matrixTimer);
-  if (egg === 'matrix') matrixTimer = setInterval(() => matrixTick.value++, 220);
-});
-
-/* Redacted bars. */
-const redactedGroups = Array.from({ length: 16 }, () => '████');
-
-/* Passive hex-word detector — when the actual SHA-256 starts with a known
-   "hex word", surface a small gold badge. Pure serendipity. */
+/* Default background + passive hex-word badge (not eggs — the box's idle state). */
 const HEX_WORDS = [
   'DEAD', 'BEEF', 'CAFE', 'BABE', 'FACE', 'FADE', 'FEED', 'DEAF', 'BEAD', 'DEED', 'SEED', 'ABED',
   'ACED', 'ACE', 'BAD', 'CAB', 'CAD', 'DAD', 'FAD', 'F00D', 'BOO', 'ADD', 'DAB', 'DAD0',
@@ -261,6 +59,64 @@ const hexWord = computed(() => {
   const first8 = hex.value.slice(0, 8);
   for (const w of HEX_WORDS) if (first8.includes(w)) return w;
   return null;
+});
+
+const eggBackground = computed(() => {
+  if (activeEgg.value) return activeEgg.value.background;
+  return hexWord.value
+    ? 'border-gold/40 bg-[color-mix(in_oklab,var(--gold)_10%,var(--surface-dim))]'
+    : 'border-line bg-surface-dim';
+});
+
+const triggerEgg = (egg: EggDef) => {
+  activeEgg.value = egg;
+  clearTimeout(eggTimer);
+  eggTimer = setTimeout(
+    () => {
+      if (activeEgg.value === egg) activeEgg.value = null;
+    },
+    egg.duration,
+  );
+  if (egg.sceneEvent === 'halScene') dispatch(RNP_EVENTS.halScene);
+  else if (egg.sceneEvent === 'daveScene') dispatch(RNP_EVENTS.daveScene);
+};
+
+watch(input, (val, oldVal) => {
+  if (!touched.value && oldVal === initialValue && val !== initialValue) touched.value = true;
+  clearTimeout(eggTimer);
+  if (val === initialValue && !touched.value) {
+    activeEgg.value = null;
+    return;
+  }
+  const match = EGG_REGISTRY.find(({ trigger }) => trigger.test(val));
+  if (match) triggerEgg(match);
+  else activeEgg.value = null;
+});
+
+/* Typing 'rnp' or 'pgp' in the input also kicks off the full-screen hex rain. */
+let lastRainInput = '';
+watch(input, (val) => {
+  const matches = /\b(rnp|pgp)\b/i.test(val);
+  if (matches && val !== lastRainInput) {
+    lastRainInput = val;
+    dispatch(RNP_EVENTS.hexRain);
+  } else if (!matches) {
+    lastRainInput = '';
+  }
+});
+
+/* 'decrypt' / 'encrypt' drive the hero animation. Decrypt wins if both present. */
+let lastHeroInput = '';
+watch(input, (val) => {
+  let evt: (typeof RNP_EVENTS)[keyof typeof RNP_EVENTS] | null = null;
+  if (/decrypt/i.test(val)) evt = RNP_EVENTS.replayHero;
+  else if (/encrypt/i.test(val)) evt = RNP_EVENTS.encryptHero;
+  if (evt && val !== lastHeroInput) {
+    lastHeroInput = val;
+    dispatch(evt);
+  } else if (!evt) {
+    lastHeroInput = '';
+  }
 });
 
 /* Rotating placeholder hints to aid discoverability without spoiling. */
@@ -284,10 +140,9 @@ const placeholder = ref(PLACEHOLDERS[0]);
 let phIdx = 0;
 let phTimer: ReturnType<typeof setInterval> | undefined;
 
-const THUNDERBIRD_PATH =
-  'M314.805 154.949H314.865C336.905 77.8991 432.945 40.2891 530.815 40.2891C598.445 40.2891 659.156 61.6991 700.776 95.6891C675.938 96.8603 651.414 101.734 628.016 110.149C661.646 122.649 690.535 141.879 711.945 165.669C695.792 162.889 679.413 161.65 663.026 161.969C703.302 220.312 724.82 289.554 724.706 360.449C724.706 553.749 568.005 710.449 374.705 710.449C184.385 710.449 24.7051 551.099 24.7051 360.449C24.7051 330.339 28.7051 299.249 36.4751 270.089C38.5151 263.969 41.3551 258.099 45.1251 255.949C49.8451 253.259 54.1451 261.279 54.8351 263.889C59.9528 283.059 66.839 301.712 75.4051 319.609C74.6551 279.649 91.7251 243.249 115.205 211.769C130.865 190.779 145.385 171.329 152.085 115.199C152.535 111.429 156.105 108.719 159.715 109.899C210.675 126.579 237.915 211.439 233.685 282.399C261.835 286.429 261.705 257.019 261.705 257.019C252.705 229.359 258.705 177.949 314.705 154.949H314.805Z';
-
 onMounted(() => {
+  supported.value = typeof crypto !== 'undefined' && !!crypto.subtle;
+  update();
   phTimer = setInterval(() => {
     if (!input.value && document.activeElement?.id !== 'fp-input') {
       phIdx = (phIdx + 1) % PLACEHOLDERS.length;
@@ -298,10 +153,8 @@ onMounted(() => {
 
 onUnmounted(() => {
   clearTimeout(eggTimer);
-  clearTimeout(timer);
-  clearInterval(matrixTimer);
+  clearTimeout(hashTimer);
   clearInterval(phTimer);
-  clearInterval(enigmaTimer);
 });
 </script>
 
@@ -333,183 +186,14 @@ onUnmounted(() => {
         :class="eggBackground"
         aria-live="polite"
       >
-        <!-- MATRIX -->
-        <div v-if="activeEgg === 'matrix'" class="font-mono">
-          <span
-            v-for="(g, i) in matrixGroups"
-            :key="`m${i}-${matrixTick}`"
-            class="matrix-glyph inline-block"
-            :style="{ animationDelay: `${(i % 8) * 60}ms` }"
-            >{{ g }}{{ i < matrixGroups.length - 1 ? ' ' : '' }}</span
-          >
-        </div>
+        <template v-if="activeEgg">
+          <component
+            :is="activeEgg.component"
+            :input="input"
+            :hex="hex"
+          />
+        </template>
 
-        <!-- REDACTED -->
-        <div v-else-if="activeEgg === 'redacted'" class="relative select-none">
-          <div class="font-mono text-black">
-            <span v-for="(g, i) in redactedGroups" :key="`r${i}`" class="opacity-90"
-              >{{ g }}{{ i < redactedGroups.length - 1 ? ' ' : '' }}</span
-            >
-          </div>
-          <div class="pointer-events-none absolute inset-0 flex items-center justify-center">
-            <span
-              class="egg-stamp rotate-[-14deg] rounded border-[3px] border-[#b91c1c] px-3 py-1 font-mono text-base font-black uppercase tracking-[0.3em] text-[#b91c1c]"
-              >Classified</span
-            >
-          </div>
-        </div>
-
-        <!-- DON'T PANIC -->
-        <div v-else-if="activeEgg === 'panic'" class="text-center">
-          <p
-            class="egg-panic-title font-sans text-2xl font-bold tracking-tight text-[#1a3a5c] md:text-3xl"
-          >
-            DON'T PANIC
-          </p>
-          <p class="mt-1 font-mono text-[0.7rem] text-[#7a5a1a]">
-            — in big, friendly letters on its cover
-          </p>
-        </div>
-
-        <!-- THUNDERBIRD -->
-        <div v-else-if="activeEgg === 'thunderbird'" class="relative flex h-10 items-center">
-          <div class="egg-bird flex items-center gap-3 whitespace-nowrap">
-            <svg
-              viewBox="0 0 750 750"
-              class="egg-bird-icon h-7 w-7 text-accent"
-              fill="currentColor"
-              aria-hidden="true"
-            >
-              <path :d="THUNDERBIRD_PATH" />
-            </svg>
-            <span class="font-mono text-sm text-accent">Powered by Thunderbird's wings.</span>
-          </div>
-        </div>
-
-        <!-- ASCII ARMOR -->
-        <div v-else-if="activeEgg === 'armor'" class="font-mono text-[0.7rem] leading-snug">
-          <div class="text-faint">-----BEGIN PGP MESSAGE-----</div>
-          <div class="my-1 break-all text-foreground/85">
-            {{ hex.slice(0, 48) }}<br />{{ hex.slice(48, 96) }}<br />{{ hex.slice(96) }}
-          </div>
-          <div class="text-faint">-----END PGP MESSAGE-----</div>
-        </div>
-
-        <!-- HAL 9000 -->
-        <div v-else-if="activeEgg === 'hal'" class="flex items-center gap-4">
-          <div class="hal-eye shrink-0"></div>
-          <div>
-            <p class="font-mono text-base font-bold tracking-wide text-[#ff1744]">I'M SORRY, DAVE.</p>
-            <p class="mt-0.5 font-mono text-xs text-[#ff1744]/70">I'm afraid I can't do that.</p>
-          </div>
-        </div>
-
-        <!-- DAVE BOWMAN (lockout terminal — full scene plays screenwide) -->
-        <div v-else-if="activeEgg === 'dave'" class="font-mono text-xs leading-snug">
-          <p class="text-cyan-300">&gt; Open the pod bay doors, HAL.</p>
-          <p class="mt-1.5 text-[#ff4757]/80">— transmission pending —</p>
-        </div>
-
-        <!-- POST-QUANTUM -->
-        <div v-else-if="activeEgg === 'pqc'" class="text-center font-sans leading-snug">
-          <p class="font-mono text-sm font-bold uppercase tracking-[0.25em] text-cyan-400 egg-pqc">
-            Harvest now.
-          </p>
-          <p
-            class="font-mono text-sm font-bold uppercase tracking-[0.25em] text-cyan-400 egg-pqc"
-            style="animation-delay: 0.35s"
-          >
-            Decrypt later.
-          </p>
-          <p class="mt-2 text-[0.7rem] text-cyan-300/70">— the post-quantum adversary is patient</p>
-        </div>
-
-        <!-- LIBREPGP -->
-        <div v-else-if="activeEgg === 'librepgp'" class="text-center font-sans leading-snug">
-          <p class="egg-librepgp text-xl font-bold tracking-tight text-gold-ink">LibrePGP</p>
-          <p class="mt-1 text-[0.7rem] italic text-gold-ink/80">— the open OpenPGP specification</p>
-          <p class="mt-1 font-mono text-[0.65rem] text-gold-ink/60">
-            brought to you by g10 · Intevation · Ribose
-          </p>
-        </div>
-
-        <!-- RIBOSE -->
-        <div v-else-if="activeEgg === 'ribose'" class="text-center font-sans leading-snug">
-          <p class="text-sm italic text-foreground">
-            "Open source is a development methodology; free software is a social movement."
-          </p>
-          <p class="mt-1.5 font-mono text-[0.7rem] text-faint">— Ribose · the people behind RNP</p>
-        </div>
-
-        <!-- PRIVACY -->
-        <div v-else-if="activeEgg === 'privacy'" class="text-center font-sans leading-snug">
-          <p class="text-sm italic text-foreground">
-            "Privacy is the power to selectively reveal oneself to the world."
-          </p>
-          <p class="mt-1.5 font-mono text-[0.7rem] text-faint">
-            — Eric Hughes · A Cypherpunk's Manifesto (1993)
-          </p>
-        </div>
-
-        <!-- DIFFIE–HELLMAN (paint-mixing key exchange) -->
-        <div v-else-if="activeEgg === 'dh'" class="dh-egg text-center">
-          <div class="flex items-center justify-center gap-3">
-            <span class="dh-can bg-rose-500" title="Alice's secret"></span>
-            <span class="font-mono text-faint">+</span>
-            <span class="dh-can bg-blue-500" title="Bob's secret"></span>
-            <span class="font-mono text-faint">→</span>
-            <span class="dh-can bg-purple-600 dh-shared" title="shared secret"></span>
-          </div>
-          <p class="mt-3 font-mono text-[0.65rem] text-purple-200/70">
-            Public exchange, private result. (Diffie–Hellman, 1976)
-          </p>
-        </div>
-
-        <!-- ONE-TIME PAD (plaintext ⊕ key = ciphertext, computed from input) -->
-        <div v-else-if="activeEgg === 'otp'" class="font-mono text-[0.7rem] leading-snug">
-          <div v-if="otpData" class="space-y-1">
-            <div class="flex gap-2">
-              <span class="w-5 shrink-0 font-bold text-emerald-400">P</span>
-              <span class="break-all text-emerald-50/90">{{ otpData.plain }}</span>
-            </div>
-            <div class="flex gap-2">
-              <span class="w-5 shrink-0 font-bold text-amber-400">K</span>
-              <span class="break-all text-emerald-50/90">{{ otpData.key }}</span>
-            </div>
-            <div class="flex gap-2">
-              <span class="w-5 shrink-0 font-bold text-rose-400">C</span>
-              <span class="break-all text-emerald-50/90">{{ otpData.cipher }}</span>
-            </div>
-          </div>
-          <p class="mt-2 text-center text-[0.65rem] text-emerald-200/80">
-            ⊕ — mathematically proven unbreakable. Use once.
-          </p>
-        </div>
-
-        <!-- ENIGMA (3-rotor stepping) -->
-        <div v-else-if="activeEgg === 'enigma'" class="text-center">
-          <div class="flex items-center justify-center gap-2">
-            <div v-for="(letter, i) in enigmaRotors" :key="i" class="enigma-rotor">
-              <span class="enigma-letter">{{ letter }}</span>
-            </div>
-          </div>
-          <p class="mt-3 font-mono text-[0.65rem] text-gray-400">
-            ³-rotor cipher · Wehrmacht, 1934–1945
-          </p>
-        </div>
-
-        <!-- PHIL ZIMMERMANN (PGP "munition" stamp, 1993–1996) -->
-        <div v-else-if="activeEgg === 'phil'" class="text-center">
-          <div class="phil-stamp egg-stamp-phil">
-            <span class="phil-stamp-text">Munition</span>
-            <span class="phil-stamp-sub">ITAR · US Customs · 1993–1996</span>
-          </div>
-          <p class="mt-3 font-mono text-[0.65rem] text-[#5a3a0a]">
-            PGP was a weapon. Zimmermann under investigation for 3 years.
-          </p>
-        </div>
-
-        <!-- DEFAULT FINGERPRINT -->
         <template v-else>
           <template v-if="groups.length">
             <span
@@ -523,10 +207,9 @@ onUnmounted(() => {
           <span v-else class="text-faint">···· ···· ···· ···· ···· ···· ···· ···· ···· ···· ···· ···· ···· ···· ···· ····</span>
         </template>
 
-        <!-- HEX WORD BADGE -->
         <div
           v-if="hexWord && !activeEgg"
-          class="egg-sparkle absolute right-2 top-2 rounded-full bg-gold/20 px-2 py-0.5 font-mono text-[0.65rem] font-bold uppercase tracking-wider text-gold-ink"
+          class="absolute right-2 top-2 rounded-full bg-gold/20 px-2 py-0.5 font-mono text-[0.65rem] font-bold uppercase tracking-wider text-gold-ink egg-sparkle"
         >
           ✨ {{ hexWord }}
         </div>
@@ -551,51 +234,6 @@ onUnmounted(() => {
 </template>
 
 <style scoped>
-.matrix-glyph {
-  color: #00ff41;
-  text-shadow: 0 0 6px #00ff41, 0 0 12px rgba(0, 255, 65, 0.4);
-  animation: matrix-flicker 0.35s steps(2, jump-none) infinite;
-}
-@keyframes matrix-flicker {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.55; }
-}
-
-.egg-stamp {
-  background: rgba(185, 28, 28, 0.08);
-  animation: stamp-in 0.5s cubic-bezier(0.5, -0.4, 0.4, 1.8) forwards;
-}
-@keyframes stamp-in {
-  0% { transform: rotate(-14deg) scale(2.6); opacity: 0; }
-  60% { transform: rotate(-14deg) scale(0.92); opacity: 1; }
-  100% { transform: rotate(-14deg) scale(1); opacity: 1; }
-}
-
-.egg-panic-title {
-  animation: panic-in 0.7s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
-}
-@keyframes panic-in {
-  0% { transform: scale(0.3) rotate(-6deg); opacity: 0; letter-spacing: 0.4em; }
-  100% { transform: scale(1) rotate(0); opacity: 1; letter-spacing: normal; }
-}
-
-.egg-bird {
-  animation: bird-fly 2.6s cubic-bezier(0.4, 0, 0.2, 1) forwards;
-}
-.egg-bird-icon {
-  transform-origin: center;
-  animation: bird-flap 0.28s ease-in-out infinite;
-}
-@keyframes bird-fly {
-  0% { transform: translateX(-110%); }
-  55% { transform: translateX(35%); }
-  100% { transform: translateX(110%); }
-}
-@keyframes bird-flap {
-  0%, 100% { transform: scaleY(1) rotate(0deg); }
-  50% { transform: scaleY(0.7) rotate(-3deg); }
-}
-
 .egg-sparkle {
   animation: sparkle 1.6s ease-in-out infinite;
 }
@@ -603,122 +241,7 @@ onUnmounted(() => {
   0%, 100% { opacity: 0.75; transform: scale(1); }
   50% { opacity: 1; transform: scale(1.1); }
 }
-
-.hal-eye {
-  width: 36px;
-  height: 36px;
-  border-radius: 50%;
-  background: radial-gradient(circle at 35% 35%, #ff6b6b 0%, #ff1744 40%, #8b0000 100%);
-  box-shadow: 0 0 16px #ff1744, inset 0 0 10px rgba(0, 0, 0, 0.5);
-  animation: hal-pulse 2.4s ease-in-out infinite;
-}
-@keyframes hal-pulse {
-  0%, 100% { box-shadow: 0 0 16px #ff1744, inset 0 0 10px rgba(0, 0, 0, 0.5); }
-  50% { box-shadow: 0 0 28px #ff1744, inset 0 0 10px rgba(0, 0, 0, 0.5); }
-}
-
-.egg-pqc {
-  animation: pqc-flicker 2.2s ease-in-out infinite;
-}
-@keyframes pqc-flicker {
-  0%, 100% { opacity: 1; text-shadow: 0 0 8px rgba(34, 211, 238, 0.5); }
-  50% { opacity: 0.85; text-shadow: 0 0 14px rgba(34, 211, 238, 0.9); }
-}
-
-.egg-librepgp {
-  animation: librepgp-glow 2.6s ease-in-out infinite;
-}
-@keyframes librepgp-glow {
-  0%, 100% { text-shadow: 0 0 8px color-mix(in oklab, var(--gold) 60%, transparent); }
-  50% { text-shadow: 0 0 16px color-mix(in oklab, var(--gold) 90%, transparent); }
-}
-
-/* Diffie–Hellman paint cans */
-.dh-can {
-  display: inline-block;
-  width: 1.75rem;
-  height: 1.75rem;
-  border-radius: 50%;
-  box-shadow: inset -3px -4px 6px rgba(0, 0, 0, 0.35), 0 2px 6px rgba(0, 0, 0, 0.25);
-}
-.dh-shared {
-  animation: dh-shimmer 2.4s ease-in-out infinite;
-}
-@keyframes dh-shimmer {
-  0%, 100% { filter: brightness(1) saturate(1); }
-  50% { filter: brightness(1.25) saturate(1.3); }
-}
-
-/* Enigma rotors */
-.enigma-rotor {
-  width: 2.5rem;
-  height: 2.5rem;
-  border-radius: 0.375rem;
-  background: linear-gradient(180deg, #2a2a2c 0%, #1a1a1c 50%, #0a0a0c 100%);
-  border: 1px solid #3a3a3c;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.06),
-    inset 0 -1px 0 rgba(0, 0, 0, 0.5),
-    0 2px 6px rgba(0, 0, 0, 0.5);
-}
-.enigma-letter {
-  font-family: var(--font-mono);
-  font-size: 1.25rem;
-  font-weight: 700;
-  color: #d0d0d4;
-  text-shadow: 0 0 8px rgba(255, 255, 255, 0.15);
-}
-
-/* Phil Zimmermann rubber stamp */
-.phil-stamp {
-  display: inline-block;
-  border: 3px double #b91c1c;
-  padding: 0.4rem 1.1rem;
-  background: rgba(185, 28, 28, 0.08);
-}
-.phil-stamp-text {
-  display: block;
-  font-family: var(--font-mono);
-  font-size: 1.25rem;
-  font-weight: 900;
-  letter-spacing: 0.25em;
-  text-transform: uppercase;
-  color: #b91c1c;
-}
-.phil-stamp-sub {
-  display: block;
-  font-family: var(--font-mono);
-  font-size: 0.55rem;
-  letter-spacing: 0.2em;
-  text-transform: uppercase;
-  color: rgba(185, 28, 28, 0.7);
-  margin-top: 0.25rem;
-}
-.egg-stamp-phil {
-  animation: phil-stamp 0.5s cubic-bezier(0.5, -0.4, 0.4, 1.8) forwards;
-}
-@keyframes phil-stamp {
-  0% { transform: rotate(-8deg) scale(3); opacity: 0; filter: blur(4px); }
-  60% { transform: rotate(-8deg) scale(0.92); opacity: 1; filter: blur(0); }
-  100% { transform: rotate(-8deg) scale(1); opacity: 1; }
-}
-
 @media (prefers-reduced-motion: reduce) {
-  .matrix-glyph,
-  .egg-stamp,
-  .egg-panic-title,
-  .egg-bird,
-  .egg-bird-icon,
-  .egg-sparkle,
-  .hal-eye,
-  .egg-pqc,
-  .egg-librepgp,
-  .dh-shared,
-  .egg-stamp-phil {
-    animation: none;
-  }
+  .egg-sparkle { animation: none; }
 }
 </style>

--- a/src/components/vue/HeroDecrypt.vue
+++ b/src/components/vue/HeroDecrypt.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { onMounted, onUnmounted, ref } from 'vue';
+import { RNP_EVENTS } from '@/lib/events';
 
 const props = defineProps<{ text: string }>();
 
@@ -64,14 +65,14 @@ onMounted(() => {
   // Passive auto-play respects reduced-motion…
   if (!reducedMotion()) run();
   // …but a user explicitly typing 'decrypt' or 'encrypt' always gets the effect.
-  window.addEventListener('rnp:replay-hero', run);
-  window.addEventListener('rnp:encrypt-hero', runEncrypt);
+  window.addEventListener(RNP_EVENTS.replayHero, run);
+  window.addEventListener(RNP_EVENTS.encryptHero, runEncrypt);
 });
 
 onUnmounted(() => {
   cancelAnimationFrame(raf);
-  window.removeEventListener('rnp:replay-hero', run);
-  window.removeEventListener('rnp:encrypt-hero', runEncrypt);
+  window.removeEventListener(RNP_EVENTS.replayHero, run);
+  window.removeEventListener(RNP_EVENTS.encryptHero, runEncrypt);
 });
 </script>
 

--- a/src/components/vue/SiteHeader.vue
+++ b/src/components/vue/SiteHeader.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue';
 import ThemeToggle from './ThemeToggle.vue';
+import { dispatch, RNP_EVENTS } from '@/lib/events';
 
 const props = defineProps<{ currentPath: string; overlay?: boolean }>();
 
@@ -89,7 +90,7 @@ const onScroll = () => {
   lastY = y;
 };
 
-const openSearch = () => window.dispatchEvent(new CustomEvent('rnp:open-search'));
+const openSearch = () => dispatch(RNP_EVENTS.openSearch);
 
 const drawerEl = ref<HTMLElement | null>(null);
 let previouslyFocused: HTMLElement | null = null;

--- a/src/components/vue/SiteSearch.vue
+++ b/src/components/vue/SiteSearch.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { nextTick, onMounted, onUnmounted, ref, watch } from 'vue';
+import { RNP_EVENTS } from '@/lib/events';
 
 interface SearchResult {
   url: string;
@@ -106,12 +107,12 @@ const onKeydown = (e: KeyboardEvent) => {
 
 onMounted(() => {
   window.addEventListener('keydown', onKeydown);
-  window.addEventListener('rnp:open-search', openModal as EventListener);
+  window.addEventListener(RNP_EVENTS.openSearch, openModal as EventListener);
 });
 
 onUnmounted(() => {
   window.removeEventListener('keydown', onKeydown);
-  window.removeEventListener('rnp:open-search', openModal as EventListener);
+  window.removeEventListener(RNP_EVENTS.openSearch, openModal as EventListener);
   document.documentElement.style.overflow = '';
 });
 </script>

--- a/src/components/vue/fingerprint/eggs/ArmorEgg.vue
+++ b/src/components/vue/fingerprint/eggs/ArmorEgg.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+const props = defineProps<{ input: string; hex: string }>();
+</script>
+
+<template>
+  <div class="font-mono text-[0.7rem] leading-snug">
+    <div class="text-faint">-----BEGIN PGP MESSAGE-----</div>
+    <div class="my-1 break-all text-foreground/85">
+      {{ props.hex.slice(0, 48) }}<br />{{ props.hex.slice(48, 96) }}<br />{{ props.hex.slice(96) }}
+    </div>
+    <div class="text-faint">-----END PGP MESSAGE-----</div>
+  </div>
+</template>

--- a/src/components/vue/fingerprint/eggs/DaveEgg.vue
+++ b/src/components/vue/fingerprint/eggs/DaveEgg.vue
@@ -1,0 +1,10 @@
+<script setup lang="ts">
+defineProps<{ input: string; hex: string }>();
+</script>
+
+<template>
+  <div class="font-mono text-xs leading-snug">
+    <p class="text-cyan-300">&gt; Open the pod bay doors, HAL.</p>
+    <p class="mt-1.5 text-[#ff4757]/80">— transmission pending —</p>
+  </div>
+</template>

--- a/src/components/vue/fingerprint/eggs/DhEgg.vue
+++ b/src/components/vue/fingerprint/eggs/DhEgg.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+defineProps<{ input: string; hex: string }>();
+</script>
+
+<template>
+  <div class="text-center">
+    <div class="flex items-center justify-center gap-3">
+      <span class="dh-can bg-rose-500" title="Alice's secret"></span>
+      <span class="font-mono text-faint">+</span>
+      <span class="dh-can bg-blue-500" title="Bob's secret"></span>
+      <span class="font-mono text-faint">→</span>
+      <span class="dh-can bg-purple-600 dh-shared" title="shared secret"></span>
+    </div>
+    <p class="mt-3 font-mono text-[0.65rem] text-purple-200/70">
+      Public exchange, private result. (Diffie–Hellman, 1976)
+    </p>
+  </div>
+</template>
+
+<style scoped>
+.dh-can {
+  display: inline-block;
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 50%;
+  box-shadow: inset -3px -4px 6px rgba(0, 0, 0, 0.35), 0 2px 6px rgba(0, 0, 0, 0.25);
+}
+.dh-shared {
+  animation: dh-shimmer 2.4s ease-in-out infinite;
+}
+@keyframes dh-shimmer {
+  0%, 100% { filter: brightness(1) saturate(1); }
+  50% { filter: brightness(1.25) saturate(1.3); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .dh-shared { animation: none; }
+}
+</style>

--- a/src/components/vue/fingerprint/eggs/EnigmaEgg.vue
+++ b/src/components/vue/fingerprint/eggs/EnigmaEgg.vue
@@ -1,0 +1,65 @@
+<script setup lang="ts">
+import { onUnmounted, ref, watch } from 'vue';
+
+defineProps<{ input: string; hex: string }>();
+
+const enigmaRotors = ref<string[]>(['R', 'N', 'P']);
+let enigmaTimer: ReturnType<typeof setInterval> | undefined;
+
+const step = () => {
+  const next = [...enigmaRotors.value];
+  for (let i = next.length - 1; i >= 0; i--) {
+    const c = next[i].charCodeAt(0);
+    const shifted = ((c - 65 + 1) % 26) + 65;
+    next[i] = String.fromCharCode(shifted);
+    if (shifted !== 65) break; // no carry
+  }
+  enigmaRotors.value = next;
+};
+
+watch(
+  () => enigmaRotors,
+  () => {
+    clearInterval(enigmaTimer);
+    enigmaTimer = setInterval(step, 600);
+  },
+  { immediate: true });
+onUnmounted(() => clearInterval(enigmaTimer));
+</script>
+
+<template>
+  <div class="text-center">
+    <div class="flex items-center justify-center gap-2">
+      <div v-for="(letter, i) in enigmaRotors" :key="i" class="enigma-rotor">
+        <span class="enigma-letter">{{ letter }}</span>
+      </div>
+    </div>
+    <p class="mt-3 font-mono text-[0.65rem] text-gray-400">
+      ³-rotor cipher · Wehrmacht, 1934–1945
+    </p>
+  </div>
+</template>
+
+<style scoped>
+.enigma-rotor {
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 0.375rem;
+  background: linear-gradient(180deg, #2a2a2c 0%, #1a1a1c 50%, #0a0a0c 100%);
+  border: 1px solid #3a3a3c;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.06),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.5),
+    0 2px 6px rgba(0, 0, 0, 0.5);
+}
+.enigma-letter {
+  font-family: var(--font-mono);
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: #d0d0d4;
+  text-shadow: 0 0 8px rgba(255, 255, 255, 0.15);
+}
+</style>

--- a/src/components/vue/fingerprint/eggs/HalEgg.vue
+++ b/src/components/vue/fingerprint/eggs/HalEgg.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+defineProps<{ input: string; hex: string }>();
+</script>
+
+<template>
+  <div class="flex items-center gap-4">
+    <div class="hal-eye shrink-0"></div>
+    <div>
+      <p class="font-mono text-base font-bold tracking-wide text-[#ff1744]">I'M SORRY, DAVE.</p>
+      <p class="mt-0.5 font-mono text-xs text-[#ff1744]/70">I'm afraid I can't do that.</p>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.hal-eye {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 35% 35%, #ff6b6b 0%, #ff1744 40%, #8b0000 100%);
+  box-shadow: 0 0 16px #ff1744, inset 0 0 10px rgba(0, 0, 0, 0.5);
+  animation: hal-pulse 2.4s ease-in-out infinite;
+}
+@keyframes hal-pulse {
+  0%, 100% { box-shadow: 0 0 16px #ff1744, inset 0 0 10px rgba(0, 0, 0, 0.5); }
+  50% { box-shadow: 0 0 28px #ff1744, inset 0 0 10px rgba(0, 0, 0, 0.5); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .hal-eye { animation: none; }
+}
+</style>

--- a/src/components/vue/fingerprint/eggs/LibrepgpEgg.vue
+++ b/src/components/vue/fingerprint/eggs/LibrepgpEgg.vue
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+defineProps<{ input: string; hex: string }>();
+</script>
+
+<template>
+  <div class="text-center font-sans leading-snug">
+    <p class="egg-librepgp text-xl font-bold tracking-tight text-gold-ink">LibrePGP</p>
+    <p class="mt-1 text-[0.7rem] italic text-gold-ink/80">— the open OpenPGP specification</p>
+    <p class="mt-1 font-mono text-[0.65rem] text-gold-ink/60">
+      brought to you by g10 · Intevation · Ribose
+    </p>
+  </div>
+</template>
+
+<style scoped>
+.egg-librepgp {
+  animation: librepgp-glow 2.6s ease-in-out infinite;
+}
+@keyframes librepgp-glow {
+  0%, 100% { text-shadow: 0 0 8px color-mix(in oklab, var(--gold) 60%, transparent); }
+  50% { text-shadow: 0 0 16px color-mix(in oklab, var(--gold) 90%, transparent); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .egg-librepgp { animation: none; }
+}
+</style>

--- a/src/components/vue/fingerprint/eggs/MatrixEgg.vue
+++ b/src/components/vue/fingerprint/eggs/MatrixEgg.vue
@@ -1,0 +1,52 @@
+<script setup lang="ts">
+import { computed, onUnmounted, ref, watch } from 'vue';
+
+const props = defineProps<{ input: string; hex: string }>();
+
+const matrixTick = ref(0);
+let matrixTimer: ReturnType<typeof setInterval> | undefined;
+const MATRIX_POOL = '0123456789ABCEFｱｲｳｴｵｶｷｸｹｺｻｼｽｾｿﾀﾁﾂ';
+
+const matrixGroups = computed(() => {
+  void matrixTick.value;
+  void props.input; // re-randomise when input changes during the egg
+  return Array.from({ length: 16 }, () =>
+    Array.from({ length: 4 }, () => MATRIX_POOL[Math.floor(Math.random() * MATRIX_POOL.length)]).join(''),
+  );
+});
+
+watch(
+  () => props.input,
+  () => {
+    clearInterval(matrixTimer);
+    matrixTimer = setInterval(() => matrixTick.value++, 220);
+  },
+  { immediate: true });
+onUnmounted(() => clearInterval(matrixTimer));
+</script>
+
+<template>
+  <div class="font-mono">
+    <span
+      v-for="(g, i) in matrixGroups"
+      :key="`m${i}-${matrixTick}`"
+      class="matrix-glyph inline-block"
+      :style="{ animationDelay: `${(i % 8) * 60}ms` }"
+    >{{ g }}{{ i < matrixGroups.length - 1 ? ' ' : '' }}</span>
+  </div>
+</template>
+
+<style scoped>
+.matrix-glyph {
+  color: #00ff41;
+  text-shadow: 0 0 6px #00ff41, 0 0 12px rgba(0, 255, 65, 0.4);
+  animation: matrix-flicker 0.35s steps(2, jump-none) infinite;
+}
+@keyframes matrix-flicker {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.55; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .matrix-glyph { animation: none; }
+}
+</style>

--- a/src/components/vue/fingerprint/eggs/OtpEgg.vue
+++ b/src/components/vue/fingerprint/eggs/OtpEgg.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue';
+
+const props = defineProps<{ input: string; hex: string }>();
+
+const otpData = ref<{ plain: string; key: string; cipher: string } | null>(null);
+
+const compute = (text: string) => {
+  if (!text) { otpData.value = null; return; }
+  const textBytes = new TextEncoder().encode(text);
+  const keyBytes = new Uint8Array(textBytes.length);
+  crypto.getRandomValues(keyBytes);
+  const cipherBytes = new Uint8Array(textBytes.length);
+  for (let i = 0; i < textBytes.length; i++) cipherBytes[i] = textBytes[i] ^ keyBytes[i];
+  const toHex = (b: Uint8Array) =>
+    Array.from(b).map((x) => x.toString(16).padStart(2, '0').toUpperCase()).join(' ');
+  otpData.value = {
+    plain: toHex(textBytes),
+    key: toHex(keyBytes),
+    cipher: toHex(cipherBytes),
+  };
+};
+
+// Snapshot once on mount; re-snapshot if input changes while the egg is active.
+watch(() => props.input, compute, { immediate: true });
+</script>
+
+<template>
+  <div class="font-mono text-[0.7rem] leading-snug">
+    <div v-if="otpData" class="space-y-1">
+      <div class="flex gap-2">
+        <span class="w-5 shrink-0 font-bold text-emerald-400">P</span>
+        <span class="break-all text-emerald-50/90">{{ otpData.plain }}</span>
+      </div>
+      <div class="flex gap-2">
+        <span class="w-5 shrink-0 font-bold text-amber-400">K</span>
+        <span class="break-all text-emerald-50/90">{{ otpData.key }}</span>
+      </div>
+      <div class="flex gap-2">
+        <span class="w-5 shrink-0 font-bold text-rose-400">C</span>
+        <span class="break-all text-emerald-50/90">{{ otpData.cipher }}</span>
+      </div>
+    </div>
+    <p class="mt-2 text-center text-[0.65rem] text-emerald-200/80">
+      ⊕ — mathematically proven unbreakable. Use once.
+    </p>
+  </div>
+</template>

--- a/src/components/vue/fingerprint/eggs/PanicEgg.vue
+++ b/src/components/vue/fingerprint/eggs/PanicEgg.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+defineProps<{ input: string; hex: string }>();
+</script>
+
+<template>
+  <div class="text-center">
+    <p class="egg-panic-title font-sans text-2xl font-bold tracking-tight text-[#1a3a5c] md:text-3xl">
+      DON'T PANIC
+    </p>
+    <p class="mt-1 font-mono text-[0.7rem] text-[#7a5a1a]">
+      — in big, friendly letters on its cover
+    </p>
+  </div>
+</template>
+
+<style scoped>
+.egg-panic-title {
+  animation: panic-in 0.7s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+}
+@keyframes panic-in {
+  0% { transform: scale(0.3) rotate(-6deg); opacity: 0; letter-spacing: 0.4em; }
+  100% { transform: scale(1) rotate(0); opacity: 1; letter-spacing: normal; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .egg-panic-title { animation: none; }
+}
+</style>

--- a/src/components/vue/fingerprint/eggs/PhilEgg.vue
+++ b/src/components/vue/fingerprint/eggs/PhilEgg.vue
@@ -1,0 +1,53 @@
+<script setup lang="ts">
+defineProps<{ input: string; hex: string }>();
+</script>
+
+<template>
+  <div class="text-center">
+    <div class="phil-stamp egg-stamp-phil">
+      <span class="phil-stamp-text">Munition</span>
+      <span class="phil-stamp-sub">ITAR · US Customs · 1993–1996</span>
+    </div>
+    <p class="mt-3 font-mono text-[0.65rem] text-[#5a3a0a]">
+      PGP was a weapon. Zimmermann under investigation for 3 years.
+    </p>
+  </div>
+</template>
+
+<style scoped>
+.phil-stamp {
+  display: inline-block;
+  border: 3px double #b91c1c;
+  padding: 0.4rem 1.1rem;
+  background: rgba(185, 28, 28, 0.08);
+}
+.phil-stamp-text {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: 1.25rem;
+  font-weight: 900;
+  letter-spacing: 0.25em;
+  text-transform: uppercase;
+  color: #b91c1c;
+}
+.phil-stamp-sub {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: 0.55rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: rgba(185, 28, 28, 0.7);
+  margin-top: 0.25rem;
+}
+.egg-stamp-phil {
+  animation: phil-stamp 0.5s cubic-bezier(0.5, -0.4, 0.4, 1.8) forwards;
+}
+@keyframes phil-stamp {
+  0% { transform: rotate(-8deg) scale(3); opacity: 0; filter: blur(4px); }
+  60% { transform: rotate(-8deg) scale(0.92); opacity: 1; filter: blur(0); }
+  100% { transform: rotate(-8deg) scale(1); opacity: 1; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .egg-stamp-phil { animation: none; }
+}
+</style>

--- a/src/components/vue/fingerprint/eggs/PqcEgg.vue
+++ b/src/components/vue/fingerprint/eggs/PqcEgg.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+defineProps<{ input: string; hex: string }>();
+</script>
+
+<template>
+  <div class="text-center font-sans leading-snug">
+    <p class="font-mono text-sm font-bold uppercase tracking-[0.25em] text-cyan-400 egg-pqc">
+      Harvest now.
+    </p>
+    <p
+      class="font-mono text-sm font-bold uppercase tracking-[0.25em] text-cyan-400 egg-pqc"
+      style="animation-delay: 0.35s"
+    >
+      Decrypt later.
+    </p>
+    <p class="mt-2 text-[0.7rem] text-cyan-300/70">— the post-quantum adversary is patient</p>
+  </div>
+</template>
+
+<style scoped>
+.egg-pqc {
+  animation: pqc-flicker 2.2s ease-in-out infinite;
+}
+@keyframes pqc-flicker {
+  0%, 100% { opacity: 1; text-shadow: 0 0 8px rgba(34, 211, 238, 0.5); }
+  50% { opacity: 0.85; text-shadow: 0 0 14px rgba(34, 211, 238, 0.9); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .egg-pqc { animation: none; }
+}
+</style>

--- a/src/components/vue/fingerprint/eggs/PrivacyEgg.vue
+++ b/src/components/vue/fingerprint/eggs/PrivacyEgg.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts">
+defineProps<{ input: string; hex: string }>();
+</script>
+
+<template>
+  <div class="text-center font-sans leading-snug">
+    <p class="text-sm italic text-foreground">
+      "Privacy is the power to selectively reveal oneself to the world."
+    </p>
+    <p class="mt-1.5 font-mono text-[0.7rem] text-faint">
+      — Eric Hughes · A Cypherpunk's Manifesto (1993)
+    </p>
+  </div>
+</template>

--- a/src/components/vue/fingerprint/eggs/RedactedEgg.vue
+++ b/src/components/vue/fingerprint/eggs/RedactedEgg.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+defineProps<{ input: string; hex: string }>();
+const redactedGroups = Array.from({ length: 16 }, () => '████');
+</script>
+
+<template>
+  <div class="relative select-none">
+    <div class="font-mono text-black">
+      <span v-for="(g, i) in redactedGroups" :key="`r${i}`" class="opacity-90"
+        >{{ g }}{{ i < redactedGroups.length - 1 ? ' ' : '' }}</span
+      >
+    </div>
+    <div class="pointer-events-none absolute inset-0 flex items-center justify-center">
+      <span
+        class="egg-stamp rotate-[-14deg] rounded border-[3px] border-[#b91c1c] px-3 py-1 font-mono text-base font-black uppercase tracking-[0.3em] text-[#b91c1c]"
+        >Classified</span
+      >
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.egg-stamp {
+  background: rgba(185, 28, 28, 0.08);
+  animation: stamp-in 0.5s cubic-bezier(0.5, -0.4, 0.4, 1.8) forwards;
+}
+@keyframes stamp-in {
+  0% { transform: rotate(-14deg) scale(2.6); opacity: 0; }
+  60% { transform: rotate(-14deg) scale(0.92); opacity: 1; }
+  100% { transform: rotate(-14deg) scale(1); opacity: 1; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .egg-stamp { animation: none; }
+}
+</style>

--- a/src/components/vue/fingerprint/eggs/RiboseEgg.vue
+++ b/src/components/vue/fingerprint/eggs/RiboseEgg.vue
@@ -1,0 +1,12 @@
+<script setup lang="ts">
+defineProps<{ input: string; hex: string }>();
+</script>
+
+<template>
+  <div class="text-center font-sans leading-snug">
+    <p class="text-sm italic text-foreground">
+      "Open source is a development methodology; free software is a social movement."
+    </p>
+    <p class="mt-1.5 font-mono text-[0.7rem] text-faint">— Ribose · the people behind RNP</p>
+  </div>
+</template>

--- a/src/components/vue/fingerprint/eggs/ThunderbirdEgg.vue
+++ b/src/components/vue/fingerprint/eggs/ThunderbirdEgg.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+defineProps<{ input: string; hex: string }>();
+
+const THUNDERBIRD_PATH =
+  'M314.805 154.949H314.865C336.905 77.8991 432.945 40.2891 530.815 40.2891C598.445 40.2891 659.156 61.6991 700.776 95.6891C675.938 96.8603 651.414 101.734 628.016 110.149C661.646 122.649 690.535 141.879 711.945 165.669C695.792 162.889 679.413 161.65 663.026 161.969C703.302 220.312 724.82 289.554 724.706 360.449C724.706 553.749 568.005 710.449 374.705 710.449C184.385 710.449 24.7051 551.099 24.7051 360.449C24.7051 330.339 28.7051 299.249 36.4751 270.089C38.5151 263.969 41.3551 258.099 45.1251 255.949C49.8451 253.259 54.1451 261.279 54.8351 263.889C59.9528 283.059 66.839 301.712 75.4051 319.609C74.6551 279.649 91.7251 243.249 115.205 211.769C130.865 190.779 145.385 171.329 152.085 115.199C152.535 111.429 156.105 108.719 159.715 109.899C210.675 126.579 237.915 211.439 233.685 282.399C261.835 286.429 261.705 257.019 261.705 257.019C252.705 229.359 258.705 177.949 314.705 154.949H314.805Z';
+</script>
+
+<template>
+  <div class="relative flex h-10 items-center">
+    <div class="egg-bird flex items-center gap-3 whitespace-nowrap">
+      <svg viewBox="0 0 750 750" class="egg-bird-icon h-7 w-7 text-accent" fill="currentColor" aria-hidden="true">
+        <path :d="THUNDERBIRD_PATH" />
+      </svg>
+      <span class="font-mono text-sm text-accent">Powered by Thunderbird's wings.</span>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.egg-bird {
+  animation: bird-fly 2.6s cubic-bezier(0.4, 0, 0.2, 1) forwards;
+}
+.egg-bird-icon {
+  transform-origin: center;
+  animation: bird-flap 0.28s ease-in-out infinite;
+}
+@keyframes bird-fly {
+  0% { transform: translateX(-110%); }
+  55% { transform: translateX(35%); }
+  100% { transform: translateX(110%); }
+}
+@keyframes bird-flap {
+  0%, 100% { transform: scaleY(1) rotate(0deg); }
+  50% { transform: scaleY(0.7) rotate(-3deg); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .egg-bird, .egg-bird-icon { animation: none; }
+}
+</style>

--- a/src/components/vue/fingerprint/registry.ts
+++ b/src/components/vue/fingerprint/registry.ts
@@ -1,0 +1,133 @@
+import type { EggDef } from './types';
+
+import MatrixEgg from './eggs/MatrixEgg.vue';
+import RedactedEgg from './eggs/RedactedEgg.vue';
+import PanicEgg from './eggs/PanicEgg.vue';
+import ThunderbirdEgg from './eggs/ThunderbirdEgg.vue';
+import ArmorEgg from './eggs/ArmorEgg.vue';
+import HalEgg from './eggs/HalEgg.vue';
+import DaveEgg from './eggs/DaveEgg.vue';
+import PqcEgg from './eggs/PqcEgg.vue';
+import LibrepgpEgg from './eggs/LibrepgpEgg.vue';
+import RiboseEgg from './eggs/RiboseEgg.vue';
+import PrivacyEgg from './eggs/PrivacyEgg.vue';
+import DhEgg from './eggs/DhEgg.vue';
+import OtpEgg from './eggs/OtpEgg.vue';
+import EnigmaEgg from './eggs/EnigmaEgg.vue';
+import PhilEgg from './eggs/PhilEgg.vue';
+
+/**
+ * Each egg is one entry — trigger, duration, background, and the component that
+ * renders inside the fingerprint box. Add a new egg by creating `eggs/FooEgg.vue`
+ * and appending one entry here.
+ */
+export const EGG_REGISTRY: EggDef[] = [
+  {
+    name: 'matrix',
+    trigger: /\b(matrix|neo|wake\s*up|mr\.?\s*anderson)\b/i,
+    duration: 5000,
+    background: 'border-emerald-500/40 bg-[#00150a]',
+    component: MatrixEgg,
+  },
+  {
+    name: 'redacted',
+    trigger: /\b(snowden|nsa|prism|classified|top\s*secret|redact(ed)?)\b/i,
+    duration: 5000,
+    background: 'border-red-900/60 bg-black',
+    component: RedactedEgg,
+  },
+  {
+    name: 'panic',
+    trigger: /\b(42|don'?t\s*panic|hitchhiker|arthur\s*dent)\b/i,
+    duration: 5000,
+    background: 'border-amber-500/50 bg-[#fdf6e3]',
+    component: PanicEgg,
+  },
+  {
+    name: 'thunderbird',
+    trigger: /\bthunderbird\b/i,
+    duration: 5000,
+    background: 'border-line bg-surface-dim',
+    component: ThunderbirdEgg,
+  },
+  {
+    name: 'armor',
+    trigger: /\b(pgp\s*message|ascii\s*armor|openpgp|4880)\b/i,
+    duration: 5000,
+    background: 'border-line bg-surface-dim',
+    component: ArmorEgg,
+  },
+  {
+    name: 'hal',
+    trigger: /\b(hal(\s*9000)?|hal9000|9000|monolith|space\s*odyssey|2001)\b/i,
+    duration: 9000,
+    background: 'border-[#ff1744]/40 bg-[#1a0606]',
+    component: HalEgg,
+    sceneEvent: 'halScene',
+  },
+  {
+    name: 'dave',
+    trigger: /\b(dave(\s*bowman)?|bowman|pod\s*bay\s*doors?)\b/i,
+    duration: 11000,
+    background: 'border-cyan-900/50 bg-[#040810]',
+    component: DaveEgg,
+    sceneEvent: 'daveScene',
+  },
+  {
+    name: 'pqc',
+    trigger: /\b(pqc|post[-\s]*quantum|quantum|9980)\b/i,
+    duration: 5000,
+    background: 'border-cyan-500/40 bg-[#061a1f]',
+    component: PqcEgg,
+  },
+  {
+    name: 'librepgp',
+    trigger: /\blibrepgp\b/i,
+    duration: 5000,
+    background:
+      'border-gold/50 bg-[color-mix(in_oklab,var(--gold)_14%,var(--surface-dim))]',
+    component: LibrepgpEgg,
+  },
+  {
+    name: 'ribose',
+    trigger: /\bribose\b/i,
+    duration: 5000,
+    background: 'border-line bg-surface-dim',
+    component: RiboseEgg,
+  },
+  {
+    name: 'privacy',
+    trigger: /\bprivacy\b/i,
+    duration: 5000,
+    background: 'border-line bg-surface-dim',
+    component: PrivacyEgg,
+  },
+  {
+    name: 'dh',
+    trigger: /\b(dh|diffie[\s-]*hellman)\b/i,
+    duration: 6000,
+    background: 'border-purple-500/40 bg-[#0e0420]',
+    component: DhEgg,
+  },
+  {
+    name: 'otp',
+    trigger: /\b(otp|one[\s-]*time[\s-]*pad|vernam)\b/i,
+    duration: 6000,
+    background: 'border-emerald-500/40 bg-[#021810]',
+    component: OtpEgg,
+  },
+  {
+    name: 'enigma',
+    trigger: /\benigma\b/i,
+    duration: 6000,
+    background: 'border-gray-500/40 bg-[#0a0a0c]',
+    component: EnigmaEgg,
+  },
+  {
+    name: 'phil',
+    trigger: /\b(phil|zimmermann|munitions?)\b/i,
+    duration: 6000,
+    background: 'border-amber-700/40 bg-[#f5edd6]',
+    component: PhilEgg,
+  },
+];

--- a/src/components/vue/fingerprint/types.ts
+++ b/src/components/vue/fingerprint/types.ts
@@ -1,0 +1,39 @@
+import type { Component } from 'vue';
+
+export type EggName =
+  | 'matrix'
+  | 'redacted'
+  | 'panic'
+  | 'thunderbird'
+  | 'armor'
+  | 'hal'
+  | 'dave'
+  | 'pqc'
+  | 'librepgp'
+  | 'ribose'
+  | 'privacy'
+  | 'dh'
+  | 'otp'
+  | 'enigma'
+  | 'phil';
+
+export interface EggProps {
+  /** Current input value (some eggs read it, e.g. otp). */
+  input: string;
+  /** Current SHA-256 hex (some eggs read it, e.g. armor). */
+  hex: string;
+}
+
+export interface EggDef {
+  name: EggName;
+  /** Input value is tested against this regex to trigger the egg. */
+  trigger: RegExp;
+  /** How long the egg stays active before auto-clearing (ms). */
+  duration: number;
+  /** Tailwind classes applied to the fingerprint box while this egg is active. */
+  background: string;
+  /** Vue component rendered inside the box. */
+  component: Component;
+  /** If set, dispatch this event when the egg fires (screenwide scene). */
+  sceneEvent?: 'halScene' | 'daveScene';
+}

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -2,12 +2,12 @@ import { defineCollection } from 'astro:content';
 import { glob } from 'astro/loaders';
 import { z } from 'astro/zod';
 import { adocLoader } from './lib/asciidoc';
+import { RNP_VERSION, RNP_MAN_PAGES } from './lib/vendor-source.mjs';
 
 /**
  * Version of the RNP release whose man pages are rendered at /docs/.
- * Bump together with `docs_ref` in src/content/software/rnp.md.
+ * Derived from `docs_ref` in src/content/software/rnp.md via vendor-source.mjs.
  */
-const RNP_VERSION = '0.18.1';
 
 const categories = z
   .union([z.string(), z.array(z.string())])
@@ -157,8 +157,7 @@ const softwareDocs = defineCollection({
 const manpages = defineCollection({
   loader: adocLoader({
     base: './vendor/rnp/src',
-    include: (rel) =>
-      ['rnp/rnp.1.adoc', 'rnpkeys/rnpkeys.1.adoc', 'lib/librnp.3.adoc'].includes(rel),
+    include: (rel) => RNP_MAN_PAGES.includes(rel),
     attributes: {
       'component-version': RNP_VERSION,
       'release-version': RNP_VERSION,

--- a/src/lib/asciidoc.ts
+++ b/src/lib/asciidoc.ts
@@ -1,8 +1,8 @@
 import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import { join, relative, sep } from 'node:path';
-import { parse as parseYaml } from 'yaml';
 import { load as loadAdoc } from 'asciidoctor';
 import type { Loader } from 'astro/loaders';
+import { parseFrontmatter } from './frontmatter.mjs';
 
 export interface SplitAdoc {
   frontMatter: Record<string, any>;
@@ -11,16 +11,7 @@ export interface SplitAdoc {
 
 /** Split YAML front matter (Jekyll-style) from an AsciiDoc body. */
 export function splitFrontMatter(raw: string): SplitAdoc {
-  const m = raw.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?/);
-  if (!m) return { frontMatter: {}, body: raw };
-  let frontMatter: Record<string, any> = {};
-  try {
-    frontMatter = (parseYaml(m[1]) ?? {}) as Record<string, any>;
-  } catch {
-    // malformed front matter — treat the file as body-only
-    return { frontMatter: {}, body: raw };
-  }
-  return { frontMatter, body: raw.slice(m[0].length) };
+  return parseFrontmatter(raw);
 }
 
 function decodeEntities(s: string): string {
@@ -60,16 +51,7 @@ export async function renderAdoc(body: string, attributes: Record<string, string
     },
   });
   const docTitleRaw = (doc.getDocumentTitle?.() as string | undefined) ?? undefined;
-  // Asciidoctor returns titles with inline markup/entities — flatten to text.
-  const docTitle = docTitleRaw
-    ?.replace(/<[^>]+>/g, '')
-    .replace(/&#x([0-9a-fA-F]+);/g, (_, h) => String.fromCodePoint(parseInt(h, 16)))
-    .replace(/&#(\d+);/g, (_, n) => String.fromCodePoint(Number(n)))
-    .replace(/&amp;/g, '&')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .trim();
+  const docTitle = docTitleRaw !== undefined ? decodeEntities(docTitleRaw) : undefined;
   const html = (await doc.convert()) as unknown as string;
   return { html, docTitle };
 }

--- a/src/lib/docs.ts
+++ b/src/lib/docs.ts
@@ -1,0 +1,9 @@
+/** Sort order for docs entries within a product. */
+export function docSort(a: string, b: string): number {
+  if (a === 'README') return -1;
+  if (b === 'README') return 1;
+  const aDev = a.startsWith('develop/') ? 1 : 0;
+  const bDev = b.startsWith('develop/') ? 1 : 0;
+  if (aDev !== bDev) return aDev - bDev;
+  return a.localeCompare(b);
+}

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -1,0 +1,31 @@
+/**
+ * Central registry of window custom-event names used by Vue islands.
+ *
+ * Importing from here lets TypeScript flag typos and gives a single rename
+ * site per event. Both senders and listeners reference the same symbol.
+ */
+
+export const RNP_EVENTS = {
+  /** SiteHeader → SiteSearch: open the Cmd+K modal. */
+  openSearch: 'rnp:open-search',
+  /** FingerprintPlayground or EasterEggs → EasterEggs: full-screen oracle rain. */
+  hexRain: 'rnp:hex-rain',
+  /** FingerprintPlayground → EasterEggs: play the HAL 9000 scene. */
+  halScene: 'rnp:hal-scene',
+  /** FingerprintPlayground → EasterEggs: play the Dave Bowman scene. */
+  daveScene: 'rnp:dave-scene',
+  /** FingerprintPlayground or EasterEggs → HeroDecrypt: scramble to readable. */
+  replayHero: 'rnp:replay-hero',
+  /** FingerprintPlayground or EasterEggs → HeroDecrypt: readable to scrambled. */
+  encryptHero: 'rnp:encrypt-hero',
+} as const;
+
+/** sessionStorage keys (distinct from custom-event names). */
+export const RNP_STORAGE = {
+  helpHinted: 'rnp:help-hinted',
+} as const;
+
+/** Dispatch a registered event with no payload. */
+export function dispatch(name: (typeof RNP_EVENTS)[keyof typeof RNP_EVENTS]): void {
+  window.dispatchEvent(new CustomEvent(name));
+}

--- a/src/lib/frontmatter.mjs
+++ b/src/lib/frontmatter.mjs
@@ -1,0 +1,21 @@
+/**
+ * YAML front-matter parser shared between the Astro layer (.ts) and the
+ * standalone Node scripts (.mjs). Kept in .mjs so fetch-sources.mjs can
+ * import it without a TS compiler.
+ */
+import { parse as parseYaml } from 'yaml';
+
+/**
+ * Split YAML front matter (Jekyll-style `---\n...\n---`) from a raw text body.
+ * Returns `{ frontMatter, body }`; if no front matter is present the whole
+ * input is returned as `body` and `frontMatter` is `{}`.
+ */
+export function parseFrontmatter(raw) {
+  const m = raw.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?/);
+  if (!m) return { frontMatter: {}, body: raw };
+  try {
+    return { frontMatter: parseYaml(m[1]) ?? {}, body: raw.slice(m[0].length) };
+  } catch {
+    return { frontMatter: {}, body: raw };
+  }
+}

--- a/src/lib/vendor-source.mjs
+++ b/src/lib/vendor-source.mjs
@@ -1,0 +1,31 @@
+/**
+ * Vendor-source conventions shared between content.config.ts and
+ * scripts/fetch-sources.mjs. Kept in .mjs so the standalone fetch script can
+ * import it without a TS compiler.
+ */
+import { readFileSync } from 'node:fs';
+import { parseFrontmatter } from './frontmatter.mjs';
+
+/** Project-relative directory sparse-cloned by fetch-sources.mjs. */
+export const VENDOR_DIR = 'vendor';
+
+/**
+ * Man-page sources for the RNP product, relative to `vendor/rnp/src/`.
+ * Sparse-checkout patterns are derived from this list.
+ */
+export const RNP_MAN_PAGES = ['rnp/rnp.1.adoc', 'rnpkeys/rnpkeys.1.adoc', 'lib/librnp.3.adoc'];
+
+/** Sparse-checkout patterns (repo-root relative) for RNP's extra paths. */
+export const RNP_EXTRA_SPARSE = RNP_MAN_PAGES.map((p) => `/src/${p}`);
+
+/**
+ * Pinned RNP release tag, read from `docs_ref` in `src/content/software/rnp.md`.
+ * `RNP_VERSION` (without the leading `v`) is derived from the tag so the two
+ * can no longer drift apart.
+ */
+const rnpFrontMatter = parseFrontmatter(
+  readFileSync('src/content/software/rnp.md', 'utf8'),
+).frontMatter;
+
+export const RNP_RELEASE_TAG = String(rnpFrontMatter.docs_ref ?? '').trim();
+export const RNP_VERSION = RNP_RELEASE_TAG.replace(/^v/, '');

--- a/src/pages/software/[id].astro
+++ b/src/pages/software/[id].astro
@@ -5,20 +5,11 @@ import PageHero from '@/components/PageHero.astro';
 import Prose from '@/components/Prose.astro';
 import InstallTabs from '@/components/vue/InstallTabs.vue';
 import { tagLabel } from '@/lib/tags';
+import { docSort } from '@/lib/docs';
 
 export async function getStaticPaths() {
   const products = await getCollection('software');
   return products.map((entry) => ({ params: { id: entry.id }, props: { entry } }));
-}
-
-/** README first, then alphabetical by slug, with develop/* pages last. */
-function docSort(a: string, b: string): number {
-  if (a === 'README') return -1;
-  if (b === 'README') return 1;
-  const aDev = a.startsWith('develop/') ? 1 : 0;
-  const bDev = b.startsWith('develop/') ? 1 : 0;
-  if (aDev !== bDev) return aDev - bDev;
-  return a.localeCompare(b);
 }
 
 const { entry } = Astro.props;

--- a/src/pages/software/[product]/docs/[...slug].astro
+++ b/src/pages/software/[product]/docs/[...slug].astro
@@ -1,6 +1,7 @@
 ---
 import { getCollection, render } from 'astro:content';
 import DocsLayout from '@/layouts/DocsLayout.astro';
+import { docSort } from '@/lib/docs';
 
 export async function getStaticPaths() {
   const entries = await getCollection('softwareDocs');
@@ -13,16 +14,6 @@ export async function getStaticPaths() {
       props: { entry },
     };
   });
-}
-
-/** README first, then alphabetical by slug, with develop/* pages last. */
-function docSort(a: string, b: string): number {
-  if (a === 'README') return -1;
-  if (b === 'README') return 1;
-  const aDev = a.startsWith('develop/') ? 1 : 0;
-  const bDev = b.startsWith('develop/') ? 1 : 0;
-  if (aDev !== bDev) return aDev - bDev;
-  return a.localeCompare(b);
 }
 
 const { entry } = Astro.props;


### PR DESCRIPTION
## Summary

Acting on the candidates from `/improve-codebase-architecture`. Four refactors, each independently motivated but cohesive as a batch.

### 1. Collapse the easter-egg scattering *(the big one)*

`FingerprintPlayground.vue` was 724 lines with each egg smeared across 6 locations (type union + EGGS array + EGG_DURATIONS + eggBackground switch + v-else-if template branch + CSS block). Adding an egg meant editing all 6.

Each egg is now a self-contained Vue SFC under `src/components/vue/fingerprint/eggs/`. The playground imports a single `EGG_REGISTRY` and renders the active egg via `<component :is>`.

```
src/components/vue/FingerprintPlayground.vue   724 → 247 lines
src/components/vue/fingerprint/types.ts        new (EggDef, EggProps)
src/components/vue/fingerprint/registry.ts     new (15 entries)
src/components/vue/fingerprint/eggs/*.vue      new (15 files)
```

Each egg owns its template, script (including any reactive state — matrix tick, OTP XOR, Enigma rotors), style, and `prefers-reduced-motion` rule. The engine stays tiny: hash, watch input, dispatch events, render the active egg component.

### 2. Surface the implicit `rnp:*` event bus

Five custom events were referenced as string literals at ~12 sites across `SiteHeader`, `SiteSearch`, `FingerprintPlayground`, `EasterEggs`, and `HeroDecrypt`. No central registry; rename was unsafe.

`src/lib/events.ts` now exports `RNP_EVENTS` (and `RNP_STORAGE` for the session key) as `as const` maps plus a `dispatch()` helper. All senders and listeners import the same symbol — rename = one edit; typo = compile error.

### 3. Deepen the vendor-source concept

`RNP_VERSION` was a hand-synced constant in `content.config.ts` that the comment warned to *"bump together with docs_ref"*. The man-page paths were duplicated between `fetch-sources.mjs` (`EXTRA_PATHS`) and `content.config.ts` (`include` regex).

`src/lib/vendor-source.mjs` now owns:

- `RNP_RELEASE_TAG` (read from `docs_ref` in `software/rnp.md`)
- `RNP_VERSION` (derived from the tag, stripping the leading `v`)
- `RNP_MAN_PAGES` + `RNP_EXTRA_SPARSE` (shared sparse-checkout paths)

`content.config.ts` and `fetch-sources.mjs` both import. The hand-sync is gone — bump `docs_ref` and `RNP_VERSION` follows.

`src/lib/frontmatter.mjs` extracts the YAML-front-matter parser shared between `asciidoc.ts` (TS) and `fetch-sources.mjs` (Node). Kept in `.mjs` so the standalone script can import it without a TS compiler.

### 4. Delete the duplicated helpers

`decodeEntities` was inlined verbatim inside `renderAdoc` (`asciidoc.ts`); `docSort` was duplicated verbatim in two software route files. Both pass the deletion test as pass-throughs.

- `renderAdoc` now calls the existing `decodeEntities` function
- `docSort` moves to `src/lib/docs.ts`; both routes import

## Skipped: front-matter parsing seam

The original review claimed `fetch-sources.mjs` and `asciidoc.ts` both parse YAML front matter. Verifying on disk: `fetch-sources.mjs` doesn't parse front matter itself — it sparse-clones repos and reads each product's front matter via the shared parser now in `frontmatter.mjs` (already done above as part of #3). The "seam" never existed as described; nothing to do here.

## Test plan

- [x] `npm run build` clean (no errors, no warnings)
- [x] HTTP 200 on `/`, `/blog/`, `/software/rnp/`, `/advisories/`
- [x] `node -e "import('./src/lib/vendor-source.mjs')..."` → `RNP_VERSION: 0.18.1`
- [x] Dev server HMR picked up all new files; egg SFCs all return 200
- [x] Each egg SFC has the `defineProps<{ input: string; hex: string }>` signature
- [x] All `rnp:` event literals replaced — `grep "rnp:" src/` returns empty (excluding `events.ts` and comments)
- [ ] Visual review of egg triggers (`matrix`, `dh`, `otp`, `enigma`, `phil`) on a real screen
- [ ] Verify HAL/Dave screenwide scenes still fire on `hal` / `dave` input
