### PR TITLE
fix: fetch-sources passes file path to parseFrontmatter (expects raw text)

### DIFF
--- a/scripts/fetch-sources.mjs
+++ b/scripts/fetch-sources.mjs
@@ -12,7 +12,7 @@
  * Existing vendor clones are reused (delete vendor/ to force a refresh).
  * Network failures are warnings, not errors — docs pages degrade gracefully.
  */
-import { existsSync, mkdirSync, readdirSync } from 'node:fs';
+import { existsSync, mkdirSync, readdirSync, readFileSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -35,7 +35,7 @@ function run(args, cwd) {
 let failures = 0;
 
 for (const file of readdirSync(softwareDir).filter((f) => f.endsWith('.md'))) {
-  const fm = parseFrontmatter(join(softwareDir, file)).frontMatter;
+  const fm = parseFrontmatter(readFileSync(join(softwareDir, file), 'utf8')).frontMatter;
   if (!fm.docs_repo) continue;
 
   const name = file.replace(/\.md$/, '');


### PR DESCRIPTION
## Summary

Regression introduced in PR #100 (the architecture refactor). When I extracted the YAML-front-matter parser to `src/lib/frontmatter.mjs`, I kept its interface as `parseFrontmatter(rawText)` — but in `fetch-sources.mjs` I called it as `parseFrontmatter(filePath)`. The regex matched nothing, every product's `docs_repo` came back undefined, every product hit the `continue`, and `vendor/` stayed empty.

CI then built with no vendor checkout, so the `softwareDocs` and `manpages` collections were empty, ~970 internal doc/manpage links went missing, and lychee reported 8 broken internal links (the README and installation hrefs that had nothing to point at).

The live site deployed from this broken build.

## Fix

```diff
- const fm = parseFrontmatter(join(softwareDir, file)).frontMatter;
+ const fm = parseFrontmatter(readFileSync(join(softwareDir, file), 'utf8')).frontMatter;
```

Matching what `asciidoc.ts` already does through its `adocLoader`.

## Test plan

- [x] `parseFrontmatter(readFileSync('src/content/software/rnp.md', 'utf8'))` returns `docs_repo` + `docs_ref` correctly
- [x] `rm -rf vendor && npm run fetch-sources` clones all 3 products (py-rnp, rnp@v0.18.1, ruby-rnp)
- [x] `npm run build`: no "collection does not exist or is empty" warnings
- [x] `npm run check:links`: "OK — all internal href/src targets exist in dist/."
- [ ] CI: next build repopulates vendor/, links job goes green, redeploy fixes the live site
